### PR TITLE
chore(attending): drop unused exports flagged by knip

### DIFF
--- a/src/services/attending/allowlist.ts
+++ b/src/services/attending/allowlist.ts
@@ -76,7 +76,7 @@ export const VENUE_KEYWORDS = [
 //   - VividSeats: sales@vividseats.com (not orders@)
 //   - TicketClub: customersupport@ticketclub.com (not info@)
 // The domain filter sidesteps this entire class of misses.
-export const VENDOR_DOMAINS = [
+const VENDOR_DOMAINS = [
   'ticketmaster.com',
   'seatgeek.com',
   'ticketclub.com',

--- a/src/services/attending/parse-axs.ts
+++ b/src/services/attending/parse-axs.ts
@@ -53,7 +53,7 @@ export function parseAxsHtml(
 }
 
 /** Parse "7/31/2025 5:30 PM" → "2025-07-31T17:30". */
-export function parseAxsDate(s: string): string | null {
+function parseAxsDate(s: string): string | null {
   const m = s.match(
     /(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2}):(\d{2})\s*(am|pm)?/i
   );

--- a/src/services/attending/parse-eventbrite.ts
+++ b/src/services/attending/parse-eventbrite.ts
@@ -111,7 +111,7 @@ export function parseEventbriteHtml(
  *
  * Captures the START time. Returns ISO 8601 (no offset).
  */
-export function parseEventbriteDate(s: string): string | null {
+function parseEventbriteDate(s: string): string | null {
   const m = s.match(
     /(?:[A-Za-z]+,\s*)?([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})\s+(?:from|at)\s+(\d{1,2}):(\d{2})\s*(am|pm)/i
   );

--- a/src/services/attending/parse-stubhub.ts
+++ b/src/services/attending/parse-stubhub.ts
@@ -95,7 +95,7 @@ export function parseStubhubHtml(
 }
 
 /** Parse "Mon, 11/14/2016, 8:00 p.m. PDT" → "2016-11-14T20:00". */
-export function parseStubhubDate(s: string): string | null {
+function parseStubhubDate(s: string): string | null {
   const m = s.match(
     /(?:[A-Za-z]+,?\s*)?(\d{1,2})\/(\d{1,2})\/(\d{4})(?:,?\s+(\d{1,2}):(\d{2})\s*(a\.?m\.?|p\.?m\.?))?/i
   );

--- a/src/services/attending/parse-vivid.ts
+++ b/src/services/attending/parse-vivid.ts
@@ -70,7 +70,7 @@ export function parseVividHtml(
 }
 
 /** Parse "Mon. May 16, 2016 7:05 PM" → "2016-05-16T19:05". */
-export function parseVividDate(s: string): string | null {
+function parseVividDate(s: string): string | null {
   const m = s.match(
     /(?:[A-Za-z]+\.?,?\s*)?([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})\s+(\d{1,2}):(\d{2})\s*(am|pm)/i
   );


### PR DESCRIPTION
## Summary

- 5 symbols flagged by `knip` as unused exports — all parser-internal date helpers (`parseAxsDate`, `parseEventbriteDate`, `parseStubhubDate`, `parseVividDate`) plus `VENDOR_DOMAINS` constant — are only referenced inside their own files.
- Drops the `export` keyword on each. The vendor-named parser entry points (`parseAxs`, `parseEventbrite`, etc.) remain public; only their internal date helpers become file-local.

## Test plan

- [x] `npm run lint:deps` no longer surfaces these symbols
- [x] `npm test` (854 pass)
- [x] `npm run lint` + `npx tsc --noEmit` + `npm run format:check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)