### PR TITLE
fix(attending): Ticketmaster transfer-complete parser + docs site

### DIFF
--- a/docs-mintlify/api-reference/attending/get-attended-event.mdx
+++ b/docs-mintlify/api-reference/attending/get-attended-event.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/attending/events/{id}
+---

--- a/docs-mintlify/api-reference/attending/get-attended-season.mdx
+++ b/docs-mintlify/api-reference/attending/get-attended-season.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/attending/seasons/{league}/{season}
+---

--- a/docs-mintlify/api-reference/attending/get-attending-stats.mdx
+++ b/docs-mintlify/api-reference/attending/get-attending-stats.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/attending/stats
+---

--- a/docs-mintlify/api-reference/attending/list-attended-events.mdx
+++ b/docs-mintlify/api-reference/attending/list-attended-events.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/attending/events
+---

--- a/docs-mintlify/api-reference/attending/list-venues.mdx
+++ b/docs-mintlify/api-reference/attending/list-venues.mdx
@@ -1,0 +1,3 @@
+---
+openapi: get /v1/attending/venues
+---

--- a/docs-mintlify/changelog.mdx
+++ b/docs-mintlify/changelog.mdx
@@ -3,6 +3,24 @@ title: Changelog
 description: API updates and new features.
 ---
 
+<Update label="April 25, 2026" tags={["New releases", "New features"]}>
+
+## Attending domain
+
+New fifth domain for live events — sports games, concerts, theater. **193 events backfilled** from Google Calendar and Gmail across 2016–2026.
+
+- [`GET /v1/attending/events`](/api-reference/attending/list-attended-events) — list attended events with filters for category (`sports` / `music` / `arts`), `event_type`, `season`, `year`, `venue_id`, and `attended` (separates "I went" from "I bought tickets but didn't go").
+- [`GET /v1/attending/events/{id}`](/api-reference/attending/get-attended-event) — single event with venue, multiple ticket rows, and league-specific `event_data` (scores, winning pitcher, my_team_won).
+- [`GET /v1/attending/seasons/{league}/{season}`](/api-reference/attending/get-attended-season) — attended games in a sports season with W/L record. Counts only games you actually attended, not the team's full record.
+- [`GET /v1/attending/venues`](/api-reference/attending/list-venues) — venue catalog with city, capacity, and lat/long.
+- [`GET /v1/attending/stats`](/api-reference/attending/get-attending-stats) — counts by category, `event_type`, and year.
+- **Seven Gmail parsers** — Ticketmaster, SeatGeek, Ticket Club, AXS, StubHub, VividSeats, and Eventbrite. Universal `schema.org/EventReservation` JSON-LD parser as a fallback.
+- **Sports enrichment** via MLB Stats API (baseball) and ESPN (NFL, NBA, WNBA, MLS, NCAAF, NCAAB) attaches scores and outcomes to past games.
+- **Cross-domain link** — concert performers can carry a `lastfm_artist_id` so a single artist row drives both your scrobble history and your concert attendance.
+- Daily incremental sync at 4:00 AM Pacific. See [Attending domain](/domains/attending).
+
+</Update>
+
 <Update label="April 24, 2026" tags={["New releases", "New features", "Improvements"]}>
 
 ## MCP server

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -8,7 +8,6 @@
     "dark": "/logo/dark.svg"
   },
   "favicon": "/favicon.svg",
-  "openapi": "openapi.json",
   "appearance": {
     "default": "system",
     "strict": false
@@ -53,6 +52,7 @@
               "domains/watching",
               "domains/reading",
               "domains/collecting",
+              "domains/attending",
               "domains/images"
             ]
           },
@@ -68,6 +68,7 @@
       },
       {
         "tab": "API Reference",
+        "openapi": "openapi.json",
         "groups": [
           {
             "group": "Listening",
@@ -171,6 +172,16 @@
               "api-reference/collecting/media-format-breakdown",
               "api-reference/collecting/owned-vs-watched-cross-reference",
               "api-reference/collecting/physical-media-item-detail"
+            ]
+          },
+          {
+            "group": "Attending",
+            "pages": [
+              "api-reference/attending/list-attended-events",
+              "api-reference/attending/get-attended-event",
+              "api-reference/attending/get-attended-season",
+              "api-reference/attending/list-venues",
+              "api-reference/attending/get-attending-stats"
             ]
           },
           {

--- a/docs-mintlify/domains/attending.mdx
+++ b/docs-mintlify/domains/attending.mdx
@@ -1,0 +1,56 @@
+---
+title: Attending
+icon: ticket
+description: Live events, tickets, and game attendance
+---
+
+## Overview
+
+The Attending domain tracks live events you bought tickets for: sports games, concerts, theater, and other one-off events. Events come from two extraction paths:
+
+- **Google Calendar** — auto-extracts ticketing details from event descriptions when Google's parsers populate them.
+- **Gmail** — per-vendor parsers walk confirmation emails from Ticketmaster, SeatGeek, Ticket Club, AXS, StubHub, VividSeats, and Eventbrite. A universal `schema.org/EventReservation` JSON-LD parser handles vendors that emit structured data.
+
+Events are enriched with team/score data from the MLB Stats API and ESPN (NFL, NBA, WNBA, MLS, NCAAF, NCAAB), and concerts can be cross-linked to Last.fm artists for unified listening + attendance views.
+
+Data syncs daily at 4:00 AM Pacific via cron, with incremental Gmail and Calendar pulls (syncToken-based).
+
+## Key endpoints
+
+| Endpoint                                                                               | Description                                                  |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| [GET /attending/events](/api-reference/attending/list-attended-events)                 | Attended events with filters (category, season, year, venue) |
+| [GET /attending/events/:id](/api-reference/attending/get-attended-event)               | Single event with venue, tickets, and event_data             |
+| [GET /attending/seasons/:league/:season](/api-reference/attending/get-attended-season) | Attended games in a sports season with W/L record            |
+| [GET /attending/venues](/api-reference/attending/list-venues)                          | Venue catalog with city, capacity, and lat/long              |
+| [GET /attending/stats](/api-reference/attending/get-attending-stats)                   | Aggregate attendance counts by category, type, and year      |
+
+## Event categories
+
+Every event has a top-level `category` and a more specific `event_type`:
+
+| Category | Event types                                                                             |
+| -------- | --------------------------------------------------------------------------------------- |
+| `sports` | `mlb_game`, `nfl_game`, `nba_game`, `wnba_game`, `mls_game`, `ncaaf_game`, `ncaab_game` |
+| `music`  | `concert`                                                                               |
+| `arts`   | `theater`, `comedy`, `other`                                                            |
+
+Sports event types determine which league API enriches the row. `event_data` carries league-specific fields — for MLB games that's `home_team`, `away_team`, `home_score`, `away_score`, `winning_pitcher`, `my_team_won`. For NFL/NCAAF games it's the equivalent shape from ESPN's scoreboard endpoint.
+
+## Attendance vs ownership
+
+The `attended` flag separates "I went" from "I bought tickets but didn't go." Both states are returned by default — pass `attended=1` to filter to confirmed attendance, `attended=0` to see no-shows. The [seasons endpoint](/api-reference/attending/get-attended-season) only counts wins/losses for events you actually attended, so a 6-game home season with one no-show reports a 5-1 attended record rather than a 5-2 team record.
+
+## Tickets and venues
+
+Each event can have multiple ticket rows — re-purchases, transfers, or multi-vendor situations all coexist. Ticket fields capture vendor-of-record details: `section`, `row`, `seat`, `quantity`, `total_price_cents`, `currency`, and the raw `order_id`.
+
+Venues are deduplicated against a curated catalog seeded with major Seattle and West-coast sports/music venues; new venues from email confirmations are auto-added with whatever name and city the parser extracts. Lat/long and capacity backfill via venue lookup over time.
+
+## Cross-domain linking
+
+Concert performers can carry a `lastfm_artist_id` populated by the performer resolver, which probes the listening domain's `lastfm_artists` table for an exact name match. This lets a single artist row drive both your scrobble history and your concert attendance.
+
+## Sports season W/L
+
+The [seasons endpoint](/api-reference/attending/get-attended-season) returns the attended games in a given league + season alongside `wins` and `losses` counts. For events flagged `attended=0` (tickets bought but you didn't go), the W/L count skips them — your attended record is what's reported, not the team's. Pair the response with a public schedule API (MLB Stats API for baseball, ESPN for football and basketball) on the consumer side to overlay attendance on the full schedule.

--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -17420,7 +17420,8 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "default": 1
+              "default": 1,
+              "example": 1
             },
             "required": false,
             "name": "page",
@@ -17431,7 +17432,8 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 100,
-              "default": 20
+              "default": 20,
+              "example": 20
             },
             "required": false,
             "name": "limit",
@@ -17444,7 +17446,8 @@
                 "sports",
                 "music",
                 "arts"
-              ]
+              ],
+              "example": "sports"
             },
             "required": false,
             "name": "category",
@@ -17452,7 +17455,8 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "mlb_game"
             },
             "required": false,
             "name": "event_type",
@@ -17463,7 +17467,8 @@
               "type": [
                 "integer",
                 "null"
-              ]
+              ],
+              "example": 2024
             },
             "required": false,
             "name": "season",
@@ -17474,7 +17479,8 @@
               "type": [
                 "integer",
                 "null"
-              ]
+              ],
+              "example": 2024
             },
             "required": false,
             "name": "year",
@@ -17485,7 +17491,8 @@
               "type": [
                 "integer",
                 "null"
-              ]
+              ],
+              "example": 12
             },
             "required": false,
             "name": "venue_id",
@@ -17498,7 +17505,8 @@
                 "null"
               ],
               "minimum": 0,
-              "maximum": 1
+              "maximum": 1,
+              "example": 1
             },
             "required": false,
             "name": "attended",
@@ -17519,65 +17527,86 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 142
                           },
                           "category": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "sports"
                           },
                           "event_type": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "mlb_game"
                           },
                           "event_date": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "2024-08-12"
                           },
                           "event_datetime": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "2024-08-12T19:10:00Z"
                           },
                           "title": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "Seattle Mariners vs Houston Astros"
                           },
                           "subtitle": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "Mariners 4, Astros 2"
                           },
                           "series_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb-2024-mariners"
                           },
                           "external_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "745423"
                           },
                           "external_source": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb_stats_api"
                           },
                           "event_data": {
                             "type": [
                               "object",
                               "null"
                             ],
-                            "additionalProperties": {}
+                            "additionalProperties": {},
+                            "example": {
+                              "season": 2024,
+                              "home_team": "Seattle Mariners",
+                              "away_team": "Houston Astros",
+                              "home_score": 4,
+                              "away_score": 2,
+                              "my_team_won": true,
+                              "winning_pitcher": "Logan Gilbert"
+                            }
                           },
                           "notes": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": null
                           },
                           "attended": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "example": true
                           },
                           "venue": {
                             "type": [
@@ -17586,46 +17615,54 @@
                             ],
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "type": "number",
+                                "example": 12
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "example": "T-Mobile Park"
                               },
                               "city": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "Seattle"
                               },
                               "state": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "WA"
                               },
                               "country": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "US"
                               },
                               "latitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47.5914
                               },
                               "longitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": -122.3325
                               },
                               "capacity": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47929
                               }
                             },
                             "required": [
@@ -17645,52 +17682,62 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 871
                                 },
                                 "vendor": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "ticketmaster"
                                 },
                                 "order_id": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "32-43215/SEA"
                                 },
                                 "section": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "147"
                                 },
                                 "row": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "15"
                                 },
                                 "seat": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "12"
                                 },
                                 "quantity": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 2
                                 },
                                 "total_price_cents": {
                                   "type": [
                                     "number",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": 8400
                                 },
                                 "currency": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "USD"
                                 },
                                 "purchased_at": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "2024-06-15T18:42:11Z"
                                 }
                               },
                               "required": [
@@ -17792,65 +17839,86 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "type": "number",
+                      "example": 142
                     },
                     "category": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "sports"
                     },
                     "event_type": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "mlb_game"
                     },
                     "event_date": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "2024-08-12"
                     },
                     "event_datetime": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "2024-08-12T19:10:00Z"
                     },
                     "title": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "Seattle Mariners vs Houston Astros"
                     },
                     "subtitle": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "Mariners 4, Astros 2"
                     },
                     "series_id": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "mlb-2024-mariners"
                     },
                     "external_id": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "745423"
                     },
                     "external_source": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "mlb_stats_api"
                     },
                     "event_data": {
                       "type": [
                         "object",
                         "null"
                       ],
-                      "additionalProperties": {}
+                      "additionalProperties": {},
+                      "example": {
+                        "season": 2024,
+                        "home_team": "Seattle Mariners",
+                        "away_team": "Houston Astros",
+                        "home_score": 4,
+                        "away_score": 2,
+                        "my_team_won": true,
+                        "winning_pitcher": "Logan Gilbert"
+                      }
                     },
                     "notes": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": null
                     },
                     "attended": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "example": true
                     },
                     "venue": {
                       "type": [
@@ -17859,46 +17927,54 @@
                       ],
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "type": "number",
+                          "example": 12
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "example": "T-Mobile Park"
                         },
                         "city": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "example": "Seattle"
                         },
                         "state": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "example": "WA"
                         },
                         "country": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "example": "US"
                         },
                         "latitude": {
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "example": 47.5914
                         },
                         "longitude": {
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "example": -122.3325
                         },
                         "capacity": {
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "example": 47929
                         }
                       },
                       "required": [
@@ -17918,52 +17994,62 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 871
                           },
                           "vendor": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "ticketmaster"
                           },
                           "order_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "32-43215/SEA"
                           },
                           "section": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "147"
                           },
                           "row": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "15"
                           },
                           "seat": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "12"
                           },
                           "quantity": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 2
                           },
                           "total_price_cents": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": 8400
                           },
                           "currency": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "USD"
                           },
                           "purchased_at": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "2024-06-15T18:42:11Z"
                           }
                         },
                         "required": [
@@ -18085,65 +18171,86 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 142
                           },
                           "category": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "sports"
                           },
                           "event_type": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "mlb_game"
                           },
                           "event_date": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "2024-08-12"
                           },
                           "event_datetime": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "2024-08-12T19:10:00Z"
                           },
                           "title": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "Seattle Mariners vs Houston Astros"
                           },
                           "subtitle": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "Mariners 4, Astros 2"
                           },
                           "series_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb-2024-mariners"
                           },
                           "external_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "745423"
                           },
                           "external_source": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb_stats_api"
                           },
                           "event_data": {
                             "type": [
                               "object",
                               "null"
                             ],
-                            "additionalProperties": {}
+                            "additionalProperties": {},
+                            "example": {
+                              "season": 2024,
+                              "home_team": "Seattle Mariners",
+                              "away_team": "Houston Astros",
+                              "home_score": 4,
+                              "away_score": 2,
+                              "my_team_won": true,
+                              "winning_pitcher": "Logan Gilbert"
+                            }
                           },
                           "notes": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": null
                           },
                           "attended": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "example": true
                           },
                           "venue": {
                             "type": [
@@ -18152,46 +18259,54 @@
                             ],
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "type": "number",
+                                "example": 12
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "example": "T-Mobile Park"
                               },
                               "city": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "Seattle"
                               },
                               "state": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "WA"
                               },
                               "country": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "US"
                               },
                               "latitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47.5914
                               },
                               "longitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": -122.3325
                               },
                               "capacity": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47929
                               }
                             },
                             "required": [
@@ -18211,52 +18326,62 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 871
                                 },
                                 "vendor": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "ticketmaster"
                                 },
                                 "order_id": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "32-43215/SEA"
                                 },
                                 "section": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "147"
                                 },
                                 "row": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "15"
                                 },
                                 "seat": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "12"
                                 },
                                 "quantity": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 2
                                 },
                                 "total_price_cents": {
                                   "type": [
                                     "number",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": 8400
                                 },
                                 "currency": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "USD"
                                 },
                                 "purchased_at": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "2024-06-15T18:42:11Z"
                                 }
                               },
                               "required": [
@@ -18341,46 +18466,54 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 12
                           },
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "T-Mobile Park"
                           },
                           "city": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "Seattle"
                           },
                           "state": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "WA"
                           },
                           "country": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "US"
                           },
                           "latitude": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": 47.5914
                           },
                           "longitude": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": -122.3325
                           },
                           "capacity": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": 47929
                           }
                         },
                         "required": [
@@ -20129,9 +20262,17 @@
           },
           {
             "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "source_ref",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 200,
+              "maximum": 1000,
               "default": 50
             },
             "required": false,

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -17420,7 +17420,8 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "default": 1
+              "default": 1,
+              "example": 1
             },
             "required": false,
             "name": "page",
@@ -17431,7 +17432,8 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 100,
-              "default": 20
+              "default": 20,
+              "example": 20
             },
             "required": false,
             "name": "limit",
@@ -17444,7 +17446,8 @@
                 "sports",
                 "music",
                 "arts"
-              ]
+              ],
+              "example": "sports"
             },
             "required": false,
             "name": "category",
@@ -17452,7 +17455,8 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "example": "mlb_game"
             },
             "required": false,
             "name": "event_type",
@@ -17463,7 +17467,8 @@
               "type": [
                 "integer",
                 "null"
-              ]
+              ],
+              "example": 2024
             },
             "required": false,
             "name": "season",
@@ -17474,7 +17479,8 @@
               "type": [
                 "integer",
                 "null"
-              ]
+              ],
+              "example": 2024
             },
             "required": false,
             "name": "year",
@@ -17485,7 +17491,8 @@
               "type": [
                 "integer",
                 "null"
-              ]
+              ],
+              "example": 12
             },
             "required": false,
             "name": "venue_id",
@@ -17498,7 +17505,8 @@
                 "null"
               ],
               "minimum": 0,
-              "maximum": 1
+              "maximum": 1,
+              "example": 1
             },
             "required": false,
             "name": "attended",
@@ -17519,65 +17527,86 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 142
                           },
                           "category": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "sports"
                           },
                           "event_type": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "mlb_game"
                           },
                           "event_date": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "2024-08-12"
                           },
                           "event_datetime": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "2024-08-12T19:10:00Z"
                           },
                           "title": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "Seattle Mariners vs Houston Astros"
                           },
                           "subtitle": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "Mariners 4, Astros 2"
                           },
                           "series_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb-2024-mariners"
                           },
                           "external_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "745423"
                           },
                           "external_source": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb_stats_api"
                           },
                           "event_data": {
                             "type": [
                               "object",
                               "null"
                             ],
-                            "additionalProperties": {}
+                            "additionalProperties": {},
+                            "example": {
+                              "season": 2024,
+                              "home_team": "Seattle Mariners",
+                              "away_team": "Houston Astros",
+                              "home_score": 4,
+                              "away_score": 2,
+                              "my_team_won": true,
+                              "winning_pitcher": "Logan Gilbert"
+                            }
                           },
                           "notes": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": null
                           },
                           "attended": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "example": true
                           },
                           "venue": {
                             "type": [
@@ -17586,46 +17615,54 @@
                             ],
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "type": "number",
+                                "example": 12
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "example": "T-Mobile Park"
                               },
                               "city": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "Seattle"
                               },
                               "state": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "WA"
                               },
                               "country": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "US"
                               },
                               "latitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47.5914
                               },
                               "longitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": -122.3325
                               },
                               "capacity": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47929
                               }
                             },
                             "required": [
@@ -17645,52 +17682,62 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 871
                                 },
                                 "vendor": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "ticketmaster"
                                 },
                                 "order_id": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "32-43215/SEA"
                                 },
                                 "section": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "147"
                                 },
                                 "row": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "15"
                                 },
                                 "seat": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "12"
                                 },
                                 "quantity": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 2
                                 },
                                 "total_price_cents": {
                                   "type": [
                                     "number",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": 8400
                                 },
                                 "currency": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "USD"
                                 },
                                 "purchased_at": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "2024-06-15T18:42:11Z"
                                 }
                               },
                               "required": [
@@ -17792,65 +17839,86 @@
                   "type": "object",
                   "properties": {
                     "id": {
-                      "type": "number"
+                      "type": "number",
+                      "example": 142
                     },
                     "category": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "sports"
                     },
                     "event_type": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "mlb_game"
                     },
                     "event_date": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "2024-08-12"
                     },
                     "event_datetime": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "2024-08-12T19:10:00Z"
                     },
                     "title": {
-                      "type": "string"
+                      "type": "string",
+                      "example": "Seattle Mariners vs Houston Astros"
                     },
                     "subtitle": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "Mariners 4, Astros 2"
                     },
                     "series_id": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "mlb-2024-mariners"
                     },
                     "external_id": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "745423"
                     },
                     "external_source": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": "mlb_stats_api"
                     },
                     "event_data": {
                       "type": [
                         "object",
                         "null"
                       ],
-                      "additionalProperties": {}
+                      "additionalProperties": {},
+                      "example": {
+                        "season": 2024,
+                        "home_team": "Seattle Mariners",
+                        "away_team": "Houston Astros",
+                        "home_score": 4,
+                        "away_score": 2,
+                        "my_team_won": true,
+                        "winning_pitcher": "Logan Gilbert"
+                      }
                     },
                     "notes": {
                       "type": [
                         "string",
                         "null"
-                      ]
+                      ],
+                      "example": null
                     },
                     "attended": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "example": true
                     },
                     "venue": {
                       "type": [
@@ -17859,46 +17927,54 @@
                       ],
                       "properties": {
                         "id": {
-                          "type": "number"
+                          "type": "number",
+                          "example": 12
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "example": "T-Mobile Park"
                         },
                         "city": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "example": "Seattle"
                         },
                         "state": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "example": "WA"
                         },
                         "country": {
                           "type": [
                             "string",
                             "null"
-                          ]
+                          ],
+                          "example": "US"
                         },
                         "latitude": {
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "example": 47.5914
                         },
                         "longitude": {
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "example": -122.3325
                         },
                         "capacity": {
                           "type": [
                             "number",
                             "null"
-                          ]
+                          ],
+                          "example": 47929
                         }
                       },
                       "required": [
@@ -17918,52 +17994,62 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 871
                           },
                           "vendor": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "ticketmaster"
                           },
                           "order_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "32-43215/SEA"
                           },
                           "section": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "147"
                           },
                           "row": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "15"
                           },
                           "seat": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "12"
                           },
                           "quantity": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 2
                           },
                           "total_price_cents": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": 8400
                           },
                           "currency": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "USD"
                           },
                           "purchased_at": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "2024-06-15T18:42:11Z"
                           }
                         },
                         "required": [
@@ -18085,65 +18171,86 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 142
                           },
                           "category": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "sports"
                           },
                           "event_type": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "mlb_game"
                           },
                           "event_date": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "2024-08-12"
                           },
                           "event_datetime": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "2024-08-12T19:10:00Z"
                           },
                           "title": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "Seattle Mariners vs Houston Astros"
                           },
                           "subtitle": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "Mariners 4, Astros 2"
                           },
                           "series_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb-2024-mariners"
                           },
                           "external_id": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "745423"
                           },
                           "external_source": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "mlb_stats_api"
                           },
                           "event_data": {
                             "type": [
                               "object",
                               "null"
                             ],
-                            "additionalProperties": {}
+                            "additionalProperties": {},
+                            "example": {
+                              "season": 2024,
+                              "home_team": "Seattle Mariners",
+                              "away_team": "Houston Astros",
+                              "home_score": 4,
+                              "away_score": 2,
+                              "my_team_won": true,
+                              "winning_pitcher": "Logan Gilbert"
+                            }
                           },
                           "notes": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": null
                           },
                           "attended": {
-                            "type": "boolean"
+                            "type": "boolean",
+                            "example": true
                           },
                           "venue": {
                             "type": [
@@ -18152,46 +18259,54 @@
                             ],
                             "properties": {
                               "id": {
-                                "type": "number"
+                                "type": "number",
+                                "example": 12
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "example": "T-Mobile Park"
                               },
                               "city": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "Seattle"
                               },
                               "state": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "WA"
                               },
                               "country": {
                                 "type": [
                                   "string",
                                   "null"
-                                ]
+                                ],
+                                "example": "US"
                               },
                               "latitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47.5914
                               },
                               "longitude": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": -122.3325
                               },
                               "capacity": {
                                 "type": [
                                   "number",
                                   "null"
-                                ]
+                                ],
+                                "example": 47929
                               }
                             },
                             "required": [
@@ -18211,52 +18326,62 @@
                               "type": "object",
                               "properties": {
                                 "id": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 871
                                 },
                                 "vendor": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "ticketmaster"
                                 },
                                 "order_id": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "32-43215/SEA"
                                 },
                                 "section": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "147"
                                 },
                                 "row": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "15"
                                 },
                                 "seat": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "12"
                                 },
                                 "quantity": {
-                                  "type": "number"
+                                  "type": "number",
+                                  "example": 2
                                 },
                                 "total_price_cents": {
                                   "type": [
                                     "number",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": 8400
                                 },
                                 "currency": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "example": "USD"
                                 },
                                 "purchased_at": {
                                   "type": [
                                     "string",
                                     "null"
-                                  ]
+                                  ],
+                                  "example": "2024-06-15T18:42:11Z"
                                 }
                               },
                               "required": [
@@ -18341,46 +18466,54 @@
                         "type": "object",
                         "properties": {
                           "id": {
-                            "type": "number"
+                            "type": "number",
+                            "example": 12
                           },
                           "name": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "T-Mobile Park"
                           },
                           "city": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "Seattle"
                           },
                           "state": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "WA"
                           },
                           "country": {
                             "type": [
                               "string",
                               "null"
-                            ]
+                            ],
+                            "example": "US"
                           },
                           "latitude": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": 47.5914
                           },
                           "longitude": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": -122.3325
                           },
                           "capacity": {
                             "type": [
                               "number",
                               "null"
-                            ]
+                            ],
+                            "example": 47929
                           }
                         },
                         "required": [
@@ -20129,9 +20262,17 @@
           },
           {
             "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "source_ref",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 200,
+              "maximum": 1000,
               "default": 50
             },
             "required": false,

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -97,7 +97,8 @@ const pendingRoute = createRoute({
   request: {
     query: z.object({
       source_type: z.enum(['gcal', 'gmail', 'manual']).optional(),
-      limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+      source_ref: z.string().optional(),
+      limit: z.coerce.number().int().min(1).max(1000).optional().default(50),
     }),
   },
   responses: {
@@ -118,7 +119,7 @@ const pendingRoute = createRoute({
 
 adminAttending.openapi(pendingRoute, async (c) => {
   const db = createDb(c.env.DB);
-  const { source_type, limit } = c.req.valid('query');
+  const { source_type, source_ref, limit } = c.req.valid('query');
 
   const rows = await db
     .select()
@@ -129,7 +130,8 @@ adminAttending.openapi(pendingRoute, async (c) => {
         isNull(attendedEventSources.eventId),
         source_type
           ? eq(attendedEventSources.sourceType, source_type)
-          : undefined
+          : undefined,
+        source_ref ? eq(attendedEventSources.sourceRef, source_ref) : undefined
       )
     )
     .orderBy(asc(attendedEventSources.createdAt))

--- a/src/routes/attending.ts
+++ b/src/routes/attending.ts
@@ -31,43 +31,62 @@ function parseJson<T = unknown>(raw: string | null): T | null {
 // ─── Schemas ────────────────────────────────────────────────────────
 
 const VenueSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  city: z.string().nullable(),
-  state: z.string().nullable(),
-  country: z.string().nullable(),
-  latitude: z.number().nullable(),
-  longitude: z.number().nullable(),
-  capacity: z.number().nullable(),
+  id: z.number().openapi({ example: 12 }),
+  name: z.string().openapi({ example: 'T-Mobile Park' }),
+  city: z.string().nullable().openapi({ example: 'Seattle' }),
+  state: z.string().nullable().openapi({ example: 'WA' }),
+  country: z.string().nullable().openapi({ example: 'US' }),
+  latitude: z.number().nullable().openapi({ example: 47.5914 }),
+  longitude: z.number().nullable().openapi({ example: -122.3325 }),
+  capacity: z.number().nullable().openapi({ example: 47929 }),
 });
 
 const TicketSchema = z.object({
-  id: z.number(),
-  vendor: z.string(),
-  order_id: z.string().nullable(),
-  section: z.string().nullable(),
-  row: z.string().nullable(),
-  seat: z.string().nullable(),
-  quantity: z.number(),
-  total_price_cents: z.number().nullable(),
-  currency: z.string(),
-  purchased_at: z.string().nullable(),
+  id: z.number().openapi({ example: 871 }),
+  vendor: z.string().openapi({ example: 'ticketmaster' }),
+  order_id: z.string().nullable().openapi({ example: '32-43215/SEA' }),
+  section: z.string().nullable().openapi({ example: '147' }),
+  row: z.string().nullable().openapi({ example: '15' }),
+  seat: z.string().nullable().openapi({ example: '12' }),
+  quantity: z.number().openapi({ example: 2 }),
+  total_price_cents: z.number().nullable().openapi({ example: 8400 }),
+  currency: z.string().openapi({ example: 'USD' }),
+  purchased_at: z
+    .string()
+    .nullable()
+    .openapi({ example: '2024-06-15T18:42:11Z' }),
 });
 
 const AttendedEventSchema = z.object({
-  id: z.number(),
-  category: z.string(),
-  event_type: z.string(),
-  event_date: z.string(),
-  event_datetime: z.string().nullable(),
-  title: z.string(),
-  subtitle: z.string().nullable(),
-  series_id: z.string().nullable(),
-  external_id: z.string().nullable(),
-  external_source: z.string().nullable(),
-  event_data: z.record(z.string(), z.any()).nullable(),
-  notes: z.string().nullable(),
-  attended: z.boolean(),
+  id: z.number().openapi({ example: 142 }),
+  category: z.string().openapi({ example: 'sports' }),
+  event_type: z.string().openapi({ example: 'mlb_game' }),
+  event_date: z.string().openapi({ example: '2024-08-12' }),
+  event_datetime: z
+    .string()
+    .nullable()
+    .openapi({ example: '2024-08-12T19:10:00Z' }),
+  title: z.string().openapi({ example: 'Seattle Mariners vs Houston Astros' }),
+  subtitle: z.string().nullable().openapi({ example: 'Mariners 4, Astros 2' }),
+  series_id: z.string().nullable().openapi({ example: 'mlb-2024-mariners' }),
+  external_id: z.string().nullable().openapi({ example: '745423' }),
+  external_source: z.string().nullable().openapi({ example: 'mlb_stats_api' }),
+  event_data: z
+    .record(z.string(), z.any())
+    .nullable()
+    .openapi({
+      example: {
+        season: 2024,
+        home_team: 'Seattle Mariners',
+        away_team: 'Houston Astros',
+        home_score: 4,
+        away_score: 2,
+        my_team_won: true,
+        winning_pitcher: 'Logan Gilbert',
+      },
+    }),
+  notes: z.string().nullable().openapi({ example: null }),
+  attended: z.boolean().openapi({ example: true }),
   venue: VenueSchema.nullable(),
   tickets: z.array(TicketSchema),
 });
@@ -84,14 +103,36 @@ const eventsRoute = createRoute({
     'Returns events you have tickets for, optionally filtered by category, event_type, season, year, and venue. Includes events you bought tickets for but did not attend (attended=false).',
   request: {
     query: z.object({
-      page: z.coerce.number().int().min(1).optional().default(1),
-      limit: z.coerce.number().int().min(1).max(100).optional().default(20),
-      category: z.enum(['sports', 'music', 'arts']).optional(),
-      event_type: z.string().optional(),
-      season: z.coerce.number().int().optional(),
-      year: z.coerce.number().int().optional(),
-      venue_id: z.coerce.number().int().optional(),
-      attended: z.coerce.number().int().min(0).max(1).optional(),
+      page: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .default(1)
+        .openapi({ example: 1 }),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(20)
+        .openapi({ example: 20 }),
+      category: z
+        .enum(['sports', 'music', 'arts'])
+        .optional()
+        .openapi({ example: 'sports' }),
+      event_type: z.string().optional().openapi({ example: 'mlb_game' }),
+      season: z.coerce.number().int().optional().openapi({ example: 2024 }),
+      year: z.coerce.number().int().optional().openapi({ example: 2024 }),
+      venue_id: z.coerce.number().int().optional().openapi({ example: 12 }),
+      attended: z.coerce
+        .number()
+        .int()
+        .min(0)
+        .max(1)
+        .optional()
+        .openapi({ example: 1 }),
     }),
   },
   responses: {

--- a/src/services/attending/extract.ts
+++ b/src/services/attending/extract.ts
@@ -320,7 +320,7 @@ function parseMessageCapture(msg: GmailMessage): ParsedGmailCandidate {
     } else if (vendor === 'ticketclub') {
       reservations = parseTicketClubHtml(html) ?? [];
     } else if (vendor === 'ticketmaster') {
-      reservations = parseTicketmasterHtml(html) ?? [];
+      reservations = parseTicketmasterHtml(html, msg.id) ?? [];
     } else if (vendor === 'axs') {
       reservations = parseAxsHtml(html) ?? [];
     } else if (vendor === 'vividseats') {
@@ -366,6 +366,7 @@ async function insertGmailSourceRows(
           internal_date: c.internal_date,
           reservations: c.reservations,
           body_text: c.body_text,
+          body_html: c.body_html,
         }),
         matchConfidence: c.reservations.length > 0 ? 1.0 : 0.3,
       })

--- a/src/services/attending/parse-ticketmaster.test.ts
+++ b/src/services/attending/parse-ticketmaster.test.ts
@@ -30,6 +30,41 @@ const MODERN_TM_HTML = `
 </body></html>
 `;
 
+// "You Got Tickets" emails carry an Order# but lead with marketing
+// copy ("The countdown to your event…"). The "X vs. Y" line
+// elsewhere should still win the title slot.
+const MODERN_INTRO_TM_HTML = `
+<html><body>
+<p>Ticketmaster</p>
+<p>The countdown to your event starts now. Save this info for your records.</p>
+<p>You Got the Tickets</p>
+<p>Order # 31-36900/SEA</p>
+<p>Seattle Mariners vs. Houston Astros</p>
+<p>Sat &bull; Apr 11 2026 &bull; 6:40 PM</p>
+<p>T-Mobile Park, Seattle, WA</p>
+</body></html>
+`;
+
+// Transfer-complete email — no Order# in the body. We synthesize
+// a reservation_number from the source_ref so the row still loads.
+const TRANSFER_COMPLETE_TM_TEXT = `
+Ticketmaster
+View as a Web Page
+Patrick, Your Ticket Transfer Is Complete!
+Received
+Accepted
+Complete
+Seattle Mariners vs. Houston Astros
+Wed, Apr 9 @ 1:10 PM
+T-Mobile Park, Seattle, WA
+Section 191, Row 2, Seat 20
+VIEW TICKETS
+This email is NOT your ticket.
+Transfer Status: Completed
+You have successfully accepted your ticket transfer from Mark.
+(c) 2025 Ticketmaster. All rights reserved.
+`;
+
 describe('parseTicketmasterHtml', () => {
   it('returns null without an order anchor', () => {
     expect(parseTicketmasterHtml('<p>Hello</p>')).toBeNull();
@@ -59,6 +94,34 @@ describe('parseTicketmasterHtml', () => {
       event_name: 'Seattle Mariners vs. Minnesota Twins',
       event_start: '2019-05-16T19:10',
       venue_name: 'T-Mobile Park',
+    });
+  });
+
+  it('prefers "X vs. Y" lines over marketing intro', () => {
+    const result = parseTicketmasterHtml(MODERN_INTRO_TM_HTML);
+    expect(result).not.toBeNull();
+    expect(result![0]).toMatchObject({
+      vendor: 'ticketmaster',
+      reservation_number: '31-36900/SEA',
+      event_name: 'Seattle Mariners vs. Houston Astros',
+      event_start: '2026-04-11T18:40',
+      venue_name: 'T-Mobile Park',
+    });
+  });
+
+  it('parses transfer-complete email without an Order#', () => {
+    const html = `<html><body><pre>${TRANSFER_COMPLETE_TM_TEXT}</pre></body></html>`;
+    const result = parseTicketmasterHtml(html, 'gmail-msg-abc123');
+    expect(result).not.toBeNull();
+    expect(result![0]).toMatchObject({
+      vendor: 'ticketmaster',
+      reservation_number: 'tm-transfer-gmail-msg-abc123',
+      event_name: 'Seattle Mariners vs. Houston Astros',
+      event_start: '2025-04-09T13:10',
+      venue_name: 'T-Mobile Park',
+      section: '191',
+      row: '2',
+      seat: '20',
     });
   });
 });

--- a/src/services/attending/parse-ticketmaster.ts
+++ b/src/services/attending/parse-ticketmaster.ts
@@ -33,10 +33,25 @@ import { stripToText } from './parse-ticketclub.js';
 import type { ParsedReservation, Vendor } from './parse-jsonld.js';
 
 export function parseTicketmasterHtml(
-  html: string | null | undefined
+  html: string | null | undefined,
+  sourceRef?: string
 ): ParsedReservation[] | null {
   if (!html) return null;
   const text = stripToText(html);
+
+  // Transfer-complete branch — Ticketmaster sends these when a friend
+  // transfers tickets to you and you accept. No Order# in the email
+  // body (the original purchase had one), so we synthesize a
+  // reservation_number from the source ref. The body is well-shaped:
+  // "Patrick, Your Ticket Transfer Is Complete!" anchor, then the
+  // game line, date, venue, and seat block.
+  if (
+    /Your Ticket Transfer (?:is|Is) [Cc]omplete/.test(text) ||
+    /Transfer Status:\s*Completed/i.test(text) ||
+    /successfully accepted your ticket transfer/i.test(text)
+  ) {
+    return parseTicketmasterTransfer(text, sourceRef);
+  }
 
   // Order number anchor — present in both layouts.
   const orderNumber =
@@ -73,19 +88,21 @@ export function parseTicketmasterHtml(
   const skipPattern =
     /^(Order|Confirmation|Section|Row|Total|Tickets?|Ticketmaster|My Account|You|Bill to|Patrick|Thanks|View|Sign|Standard|Allow|Protect|We'd|Take|Survey|Add to|Buyer|Special|Notes?|Important|Privacy|Unsubscribe|Forward|Visit|Help|Contact|Customer|Subject|To:|From:|©|Copyright|Powered)/i;
 
+  // Prefer lines matching "X vs. Y" or "X vs Y" — sports games and
+  // many concerts use this shape. Walk the whole list looking for
+  // the strongest title candidate before falling back to the first
+  // non-skipped line. This keeps email intros like "The countdown to
+  // your event starts now…" from being mis-titled as the event.
   let eventName = '';
   let eventStart: string | null = null;
   let dateLineIdx = -1;
+  let versusCandidate: string | null = null;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (skipPattern.test(line)) continue;
-    if (line.startsWith('$')) continue; // skip dollar-amount lines
-    if (/^\d+(?:[,.]\d+)?$/.test(line)) continue; // skip pure numbers
+    if (line.startsWith('$')) continue;
+    if (/^\d+(?:[,.]\d+)?$/.test(line)) continue;
     if (line === orderNumber) continue;
-    // Skip lines that describe quantity ("4 General Admission ticket(s)
-    // in Section GENADM") — these contain section info but aren't event
-    // names. The literal "ticket(s)" / "ticket" + "Section" combo is a
-    // strong signal.
     if (/\bticket\(?s?\)?\b.*\bSection\b/i.test(line)) continue;
     if (/^\d+\s+\w+\s+ticket/i.test(line)) continue;
     const parsedDate = parseTicketmasterDate(line);
@@ -94,10 +111,19 @@ export function parseTicketmasterHtml(
       dateLineIdx = i;
       continue;
     }
+    if (
+      !versusCandidate &&
+      / vs\.? /i.test(line) &&
+      line.length > 5 &&
+      line.length < 200
+    ) {
+      versusCandidate = line;
+    }
     if (!eventName && line.length > 2 && line.length < 200) {
       eventName = line;
     }
   }
+  if (versusCandidate) eventName = versusCandidate;
 
   // Venue: line right before or after the date line, picking whichever
   // looks like a venue.
@@ -132,6 +158,133 @@ export function parseTicketmasterHtml(
       currency: 'USD',
     },
   ];
+}
+
+/**
+ * Parse a Ticketmaster transfer-completion email body into a
+ * ParsedReservation. These emails don't carry an Order#, so we
+ * synthesize a reservation_number from the source_ref (preferred) or a
+ * content fingerprint (fallback).
+ *
+ * Body shape (real example):
+ *   Patrick, Your Ticket Transfer Is Complete!
+ *   ...
+ *   Seattle Mariners vs. Houston Astros
+ *   Wed, Apr 9 @ 1:10 PM
+ *   T-Mobile Park, Seattle, WA
+ *   Section 191, Row 2, Seat 20
+ *   ...
+ *   (c) 2025 Ticketmaster
+ */
+function parseTicketmasterTransfer(
+  text: string,
+  sourceRef: string | undefined
+): ParsedReservation[] | null {
+  const lines = text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Year inference: prefer the copyright line, fall back to current year.
+  const copyrightYear = matchSimple(text, /\(c\)\s*(\d{4})\s*Ticketmaster/i);
+  const inferredYear = copyrightYear ?? String(new Date().getFullYear());
+
+  // Find "X vs. Y" line (event name).
+  let eventName: string | null = null;
+  let dateLine: string | null = null;
+  let venueLine: string | null = null;
+  let seatLine: string | null = null;
+  for (const line of lines) {
+    if (!eventName && / vs\.? /i.test(line) && line.length < 150) {
+      eventName = line;
+      continue;
+    }
+    if (
+      !dateLine &&
+      /\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)/i.test(line) &&
+      /@/.test(line)
+    ) {
+      dateLine = line;
+      continue;
+    }
+    if (!venueLine && /,\s*[A-Z]{2}\b/.test(line) && line.length < 200) {
+      venueLine = line;
+      continue;
+    }
+    if (!seatLine && /Section\s+\S/i.test(line) && /Row\s+\S/i.test(line)) {
+      seatLine = line;
+    }
+  }
+  if (!eventName || !dateLine) return null;
+
+  const eventStart = parseTicketmasterTransferDate(dateLine, inferredYear);
+  const section = seatLine
+    ? matchSimple(seatLine, /Section\s+([^,]+?)(?:,|$)/i)
+    : null;
+  const row = seatLine ? matchSimple(seatLine, /Row\s+([^,]+?)(?:,|$)/i) : null;
+  const seat = seatLine
+    ? matchSimple(seatLine, /Seat\s+([^,]+?)(?:,|$)/i)
+    : null;
+
+  return [
+    {
+      vendor: 'ticketmaster' as Vendor,
+      reservation_number: sourceRef
+        ? `tm-transfer-${sourceRef}`
+        : `tm-transfer-${eventName.slice(0, 12)}-${eventStart ?? 'unknown'}`,
+      event_name: eventName,
+      event_start: eventStart,
+      venue_name: venueLine ? cleanVenueName(venueLine) : null,
+      venue_address: venueLine,
+      section,
+      row,
+      seat,
+      total_price_cents: null,
+      currency: 'USD',
+    },
+  ];
+}
+
+/**
+ * Parse Ticketmaster's transfer-email date format (no year):
+ *   "Wed, Apr 9 @ 1:10 PM"
+ *   "Sat • Jul 13 • 6:40 PM"
+ */
+function parseTicketmasterTransferDate(
+  line: string,
+  year: string
+): string | null {
+  const m = line.match(
+    /([A-Za-z]+)\s+(\d{1,2})\s*[@•·-]\s*(\d{1,2}):(\d{2})\s*(am|pm)/i
+  );
+  if (!m) return null;
+  const months: Record<string, string> = {
+    jan: '01',
+    feb: '02',
+    mar: '03',
+    apr: '04',
+    may: '05',
+    jun: '06',
+    jul: '07',
+    aug: '08',
+    sep: '09',
+    oct: '10',
+    nov: '11',
+    dec: '12',
+  };
+  const mm = months[m[1].slice(0, 3).toLowerCase()];
+  if (!mm) return null;
+  const dd = m[2].padStart(2, '0');
+  const hour12 = parseInt(m[3], 10);
+  const min = parseInt(m[4], 10);
+  const ampm = m[5].toLowerCase();
+  const hour24 =
+    ampm === 'pm' && hour12 !== 12
+      ? hour12 + 12
+      : ampm === 'am' && hour12 === 12
+        ? 0
+        : hour12;
+  return `${year}-${mm}-${dd}T${String(hour24).padStart(2, '0')}:${String(min).padStart(2, '0')}`;
 }
 
 function cleanVenueName(line: string): string {

--- a/src/services/attending/reprocess.ts
+++ b/src/services/attending/reprocess.ts
@@ -146,7 +146,7 @@ export async function reprocessPendingSources(
       } else if (senderVendor === 'ticketclub') {
         reservations = parseTicketClubHtml(html) ?? [];
       } else if (senderVendor === 'ticketmaster') {
-        reservations = parseTicketmasterHtml(html) ?? [];
+        reservations = parseTicketmasterHtml(html, row.sourceRef) ?? [];
       } else if (senderVendor === 'axs') {
         reservations = parseAxsHtml(html) ?? [];
       } else if (senderVendor === 'vividseats') {

--- a/src/services/google/gmail-client.ts
+++ b/src/services/google/gmail-client.ts
@@ -181,6 +181,17 @@ const SUBJECT_REJECT = [
   'how was it',
   'rate your experience',
   'tell us about',
+  // Outgoing transfers — user is GIVING tickets away, not attending.
+  // "Your ticket transfer to Brad is on the way" — Brad goes, not user.
+  'transfer to',
+  'is on the way',
+  // Pre-acceptance offers from Mariners Fancare / friends — the
+  // companion "all set to see"/"got tickets" email is the actual
+  // confirmation we want. Skip the offer; trust the acceptance.
+  'just sent you',
+  'sent you ticket',
+  'sent you 1 seattle',
+  'kids club',
 ];
 
 const SUBJECT_ACCEPT = [
@@ -193,6 +204,14 @@ const SUBJECT_ACCEPT = [
   'tickets for',
   'ticket purchase',
   'thanks for your order',
+  // Ticketmaster transfer-complete confirmations.
+  "you're all set to see",
+  'you got tickets to',
+  'you got the tickets',
+  'transfer is complete',
+  'transfer went through',
+  // Generic Ticketmaster purchase confirmations.
+  'thanks for your',
 ];
 
 export type SubjectVerdict = 'accept' | 'reject' | 'uncertain';


### PR DESCRIPTION
## Summary

Three things land here:

1. **Parser fix** — Ticketmaster's transfer-completion emails (\"Patrick, Your Ticket Transfer Is Complete!\") were dropping on the floor because the existing parser required an Order# anchor. New branch handles them, synthesizing a reservation_number from the Gmail source_ref. Plus the modern parser now prefers \"X vs. Y\" lines for event titles instead of mis-titling on email intros like \"The countdown to your event starts now…\".
2. **Subject filter tightening** — outgoing transfers (\"transfer to Brad is on the way\"), pre-acceptance offers (\"X Just Sent You N Tickets\"), and Mariners Fancare welcome emails are now rejected. The acceptance-side confirmations (\"You're all set to see\", \"You Got Tickets To\") are explicitly accepted.
3. **Bug fix** — \`insertGmailSourceRows\` was capturing \`body_html\` from the message but dropping it on insert. Now persisted alongside \`body_text\` so the reprocess endpoint can run vendor parsers against HTML-only emails.

## Docs

- New \`docs-mintlify/domains/attending.mdx\` (matches the style/length of the other 6 domain pages).
- Five auto-generated API reference pages in \`docs-mintlify/api-reference/attending/\`.
- Nav: Attending added to Basics + new API Reference group. \`openapi\` config moved to the API Reference tab to clear a \`mint validate\` warning.
- Real-data examples on \`AttendedEventSchema\`, \`VenueSchema\`, \`TicketSchema\`, and \`listAttendedEvents\` query params.
- Changelog entry for April 25, 2026.

## Why

\`/v1/attending/events?event_type=mlb_game&year=2026\` showed only 2 games when the user knows of more. Investigation: the April 11 Mariners email loaded with title \"The countdown to your event starts now…\" and event_type \"concert\" — wrong both ways. Plus dozens of pending Ticketmaster transfer-completes never made it to canonical events because the parser bailed without an Order#.

## Test plan

- [x] All 856 vitest cases pass locally
- [x] Type check, ESLint, Prettier, OpenAPI lint, claude-code-lint all green
- [x] \`mint validate\` passes with zero warnings
- [x] New parser tests cover the transfer-complete branch and the versus-line title preference
- [ ] Post-merge: run \`POST /v1/admin/attending/reprocess\` to drain the existing pending queue with the improved parser
- [ ] Post-merge: verify Mariners 2026 count jumps and the April 11 game gets a correct \"Seattle Mariners vs. Houston Astros\" title

🤖 Generated with [Claude Code](https://claude.com/claude-code)