### PR TITLE
fix(attending): force-update loaded titles + transfer year inference

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -729,6 +729,9 @@
           "loaded": {
             "type": "integer"
           },
+          "updated_loaded": {
+            "type": "integer"
+          },
           "failures": {
             "type": "array",
             "items": {
@@ -754,6 +757,7 @@
           "refetched",
           "newly_parsed",
           "loaded",
+          "updated_loaded",
           "failures"
         ]
       },
@@ -775,6 +779,10 @@
             "default": 1000
           },
           "dry_run": {
+            "type": "boolean",
+            "default": false
+          },
+          "force_update_loaded": {
             "type": "boolean",
             "default": false
           }

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -729,6 +729,9 @@
           "loaded": {
             "type": "integer"
           },
+          "updated_loaded": {
+            "type": "integer"
+          },
           "failures": {
             "type": "array",
             "items": {
@@ -754,6 +757,7 @@
           "refetched",
           "newly_parsed",
           "loaded",
+          "updated_loaded",
           "failures"
         ]
       },
@@ -775,6 +779,10 @@
             "default": 1000
           },
           "dry_run": {
+            "type": "boolean",
+            "default": false
+          },
+          "force_update_loaded": {
             "type": "boolean",
             "default": false
           }

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -494,6 +494,7 @@ const ReprocessBody = z
     refetch_missing_body: z.boolean().optional().default(true),
     limit: z.number().int().min(1).max(2000).optional().default(1000),
     dry_run: z.boolean().optional().default(false),
+    force_update_loaded: z.boolean().optional().default(false),
   })
   .openapi('AttendingReprocessBody');
 
@@ -504,6 +505,7 @@ const ReprocessResponse = z
     refetched: z.number().int(),
     newly_parsed: z.number().int(),
     loaded: z.number().int(),
+    updated_loaded: z.number().int(),
     failures: z.array(
       z.object({ source_id: z.number().int(), reason: z.string() })
     ),
@@ -541,6 +543,7 @@ adminAttending.openapi(reprocessRoute, async (c) => {
     refetch_missing_body?: boolean;
     limit?: number;
     dry_run?: boolean;
+    force_update_loaded?: boolean;
   };
   const body: ReprocessOpts = await c.req
     .json<ReprocessOpts>()
@@ -552,6 +555,7 @@ adminAttending.openapi(reprocessRoute, async (c) => {
       refetchMissingBody: body.refetch_missing_body ?? true,
       limit: body.limit ?? 1000,
       dryRun: body.dry_run ?? false,
+      forceUpdateLoaded: body.force_update_loaded ?? false,
     });
     return c.json({
       status: 'completed' as const,
@@ -559,6 +563,7 @@ adminAttending.openapi(reprocessRoute, async (c) => {
       refetched: result.refetched,
       newly_parsed: result.newly_parsed,
       loaded: result.loaded,
+      updated_loaded: result.updated_loaded,
       failures: result.failures,
     });
   } catch (error) {

--- a/src/services/attending/extract.ts
+++ b/src/services/attending/extract.ts
@@ -320,7 +320,10 @@ function parseMessageCapture(msg: GmailMessage): ParsedGmailCandidate {
     } else if (vendor === 'ticketclub') {
       reservations = parseTicketClubHtml(html) ?? [];
     } else if (vendor === 'ticketmaster') {
-      reservations = parseTicketmasterHtml(html, msg.id) ?? [];
+      const internalDate = new Date(
+        parseInt(msg.internalDate, 10)
+      ).toISOString();
+      reservations = parseTicketmasterHtml(html, msg.id, internalDate) ?? [];
     } else if (vendor === 'axs') {
       reservations = parseAxsHtml(html) ?? [];
     } else if (vendor === 'vividseats') {

--- a/src/services/attending/parse-ticketmaster.ts
+++ b/src/services/attending/parse-ticketmaster.ts
@@ -34,7 +34,8 @@ import type { ParsedReservation, Vendor } from './parse-jsonld.js';
 
 export function parseTicketmasterHtml(
   html: string | null | undefined,
-  sourceRef?: string
+  sourceRef?: string,
+  messageDate?: string | null
 ): ParsedReservation[] | null {
   if (!html) return null;
   const text = stripToText(html);
@@ -50,7 +51,7 @@ export function parseTicketmasterHtml(
     /Transfer Status:\s*Completed/i.test(text) ||
     /successfully accepted your ticket transfer/i.test(text)
   ) {
-    return parseTicketmasterTransfer(text, sourceRef);
+    return parseTicketmasterTransfer(text, sourceRef, messageDate);
   }
 
   // Order number anchor — present in both layouts.
@@ -178,16 +179,24 @@ export function parseTicketmasterHtml(
  */
 function parseTicketmasterTransfer(
   text: string,
-  sourceRef: string | undefined
+  sourceRef: string | undefined,
+  messageDate: string | null | undefined
 ): ParsedReservation[] | null {
   const lines = text
     .split('\n')
     .map((s) => s.trim())
     .filter(Boolean);
 
-  // Year inference: prefer the copyright line, fall back to current year.
+  // Year inference: prefer the copyright line, then the email's
+  // internal_date (transfers usually arrive within ~2 weeks of the
+  // game), then current year as a final fallback. Without this,
+  // older transfer emails (no copyright string) inherit "today"
+  // and end up dated years in the future.
   const copyrightYear = matchSimple(text, /\(c\)\s*(\d{4})\s*Ticketmaster/i);
-  const inferredYear = copyrightYear ?? String(new Date().getFullYear());
+  const messageYear =
+    messageDate && /^\d{4}/.test(messageDate) ? messageDate.slice(0, 4) : null;
+  const inferredYear =
+    copyrightYear ?? messageYear ?? String(new Date().getFullYear());
 
   // Find "X vs. Y" line (event name).
   let eventName: string | null = null;

--- a/src/services/attending/reprocess.ts
+++ b/src/services/attending/reprocess.ts
@@ -11,7 +11,10 @@
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { Database } from '../../db/client.js';
 import type { Env } from '../../types/env.js';
-import { attendedEventSources } from '../../db/schema/attending.js';
+import {
+  attendedEvents,
+  attendedEventSources,
+} from '../../db/schema/attending.js';
 import { getGoogleAccessToken } from '../google/auth.js';
 import { getGmailMessage, judgeSubject } from '../google/gmail-client.js';
 import { enrichCandidate } from './enrich.js';
@@ -34,6 +37,14 @@ export interface ReprocessOptions {
   refetchMissingBody?: boolean; // re-pull from Gmail when body_text/html absent
   limit?: number;
   dryRun?: boolean;
+  // When true, also reprocess source rows that already linked to an
+  // event AND overwrite the event's title/event_type when the new
+  // parse produces a confidently-better title (matches "X vs. Y").
+  // Use after a parser fix that changes title heuristics — earlier
+  // bad titles ("The countdown to your event…") get rewritten to
+  // the actual game line. Idempotent: re-running won't degrade good
+  // titles since the new parse won't differ.
+  forceUpdateLoaded?: boolean;
 }
 
 export interface ReprocessResult {
@@ -41,6 +52,7 @@ export interface ReprocessResult {
   refetched: number;
   newly_parsed: number;
   loaded: number;
+  updated_loaded: number;
   failures: Array<{ source_id: number; reason: string }>;
 }
 
@@ -54,12 +66,14 @@ export async function reprocessPendingSources(
     refetchMissingBody = true,
     limit = 1000,
     dryRun = false,
+    forceUpdateLoaded = false,
   } = opts;
   const result: ReprocessResult = {
     scanned: 0,
     refetched: 0,
     newly_parsed: 0,
     loaded: 0,
+    updated_loaded: 0,
     failures: [],
   };
 
@@ -77,7 +91,7 @@ export async function reprocessPendingSources(
       and(
         eq(attendedEventSources.userId, 1),
         eq(attendedEventSources.sourceType, 'gmail'),
-        isNull(attendedEventSources.eventId),
+        forceUpdateLoaded ? undefined : isNull(attendedEventSources.eventId),
         vendorClause
       )
     )
@@ -146,7 +160,12 @@ export async function reprocessPendingSources(
       } else if (senderVendor === 'ticketclub') {
         reservations = parseTicketClubHtml(html) ?? [];
       } else if (senderVendor === 'ticketmaster') {
-        reservations = parseTicketmasterHtml(html, row.sourceRef) ?? [];
+        reservations =
+          parseTicketmasterHtml(
+            html,
+            row.sourceRef,
+            (raw.internal_date as string) ?? null
+          ) ?? [];
       } else if (senderVendor === 'axs') {
         reservations = parseAxsHtml(html) ?? [];
       } else if (senderVendor === 'vividseats') {
@@ -162,6 +181,60 @@ export async function reprocessPendingSources(
     result.newly_parsed++;
 
     if (dryRun) continue;
+
+    // Force-update path: source row is already linked to an event,
+    // and the new parse produced a "X vs. Y" title that the existing
+    // event lacks. Overwrite title (and re-infer event_type from the
+    // new title via the enricher). No new event row created — we
+    // update in place, leave tickets/performers untouched.
+    if (forceUpdateLoaded && row.eventId != null) {
+      const newTitle = reservations[0].event_name;
+      const hasVersus =
+        newTitle != null && / vs\.? /i.test(newTitle) && newTitle.length > 5;
+      if (!hasVersus) continue;
+
+      const enrichedForType = await enrichCandidate(
+        {
+          source_ref: row.sourceRef,
+          source_type: 'gmail',
+          event_date: '2000-01-01',
+          event_datetime: null,
+          title: newTitle,
+          location: reservations[0].venue_address ?? reservations[0].venue_name,
+        },
+        db,
+        env
+      );
+      const newEventType = enrichedForType?.event_type ?? null;
+      const newCategory = enrichedForType?.category ?? null;
+
+      const [existingEvent] = await db
+        .select()
+        .from(attendedEvents)
+        .where(eq(attendedEvents.id, row.eventId));
+      if (!existingEvent) continue;
+
+      const existingHasVersus =
+        existingEvent.title != null && / vs\.? /i.test(existingEvent.title);
+
+      if (existingHasVersus) continue;
+
+      const usableCategory =
+        newCategory && newCategory !== 'unknown'
+          ? (newCategory as 'sports' | 'music' | 'arts')
+          : existingEvent.category;
+      await db
+        .update(attendedEvents)
+        .set({
+          title: newTitle,
+          eventType: newEventType ?? existingEvent.eventType,
+          category: usableCategory,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(eq(attendedEvents.id, row.eventId));
+      result.updated_loaded++;
+      continue;
+    }
 
     // Persist the new reservations on the source row, then enrich+load.
     raw.reservations = reservations;


### PR DESCRIPTION
## Summary

Two follow-up fixes after the previous parser PR:

1. **Force-update mode for reprocess.** When the prior PR fixed the title-detection logic, only *unloaded* source rows benefited. The five events already loaded with bad titles (\"The countdown to your event starts now…\") stayed wrong, since the COALESCE-style merge in load.ts only fills nulls. New \`force_update_loaded: true\` flag walks loaded source rows too, re-parses, and overwrites the linked event's title + event_type ONLY when the new parse produces a confident \"X vs. Y\" title that the existing one lacks. Idempotent.
2. **Transfer year inference.** The Ticketmaster transfer-complete branch I added in PR #45 inferred year from the email's \"(c) YYYY Ticketmaster\" copyright line, falling back to the current year. Older transfer emails (no copyright string) inherited \"today\" — a 2017 game ended up dated 2026-05-16. Now falls through copyright → email \`internal_date\` → current year.

## Test plan

- [x] All 856 vitest cases pass locally
- [x] Type check, ESLint, OpenAPI snapshot all green
- [ ] Post-merge: \`POST /v1/admin/attending/reprocess\` with \`{vendor: 'ticketmaster.com', force_update_loaded: true, refetch_missing_body: false}\` to fix the five mis-titled events
- [ ] Verify the 2026-05-16 \"Cleveland Indians\" event re-dates to 2017

🤖 Generated with [Claude Code](https://claude.com/claude-code)