### PR TITLE
fix(attending): refetch when body_html missing + body_text anemic

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -729,6 +729,9 @@
           "loaded": {
             "type": "integer"
           },
+          "updated_loaded": {
+            "type": "integer"
+          },
           "failures": {
             "type": "array",
             "items": {
@@ -754,6 +757,7 @@
           "refetched",
           "newly_parsed",
           "loaded",
+          "updated_loaded",
           "failures"
         ]
       },
@@ -775,6 +779,10 @@
             "default": 1000
           },
           "dry_run": {
+            "type": "boolean",
+            "default": false
+          },
+          "force_update_loaded": {
             "type": "boolean",
             "default": false
           }

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -729,6 +729,9 @@
           "loaded": {
             "type": "integer"
           },
+          "updated_loaded": {
+            "type": "integer"
+          },
           "failures": {
             "type": "array",
             "items": {
@@ -754,6 +757,7 @@
           "refetched",
           "newly_parsed",
           "loaded",
+          "updated_loaded",
           "failures"
         ]
       },
@@ -775,6 +779,10 @@
             "default": 1000
           },
           "dry_run": {
+            "type": "boolean",
+            "default": false
+          },
+          "force_update_loaded": {
             "type": "boolean",
             "default": false
           }

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -494,6 +494,7 @@ const ReprocessBody = z
     refetch_missing_body: z.boolean().optional().default(true),
     limit: z.number().int().min(1).max(2000).optional().default(1000),
     dry_run: z.boolean().optional().default(false),
+    force_update_loaded: z.boolean().optional().default(false),
   })
   .openapi('AttendingReprocessBody');
 
@@ -504,6 +505,7 @@ const ReprocessResponse = z
     refetched: z.number().int(),
     newly_parsed: z.number().int(),
     loaded: z.number().int(),
+    updated_loaded: z.number().int(),
     failures: z.array(
       z.object({ source_id: z.number().int(), reason: z.string() })
     ),
@@ -541,6 +543,7 @@ adminAttending.openapi(reprocessRoute, async (c) => {
     refetch_missing_body?: boolean;
     limit?: number;
     dry_run?: boolean;
+    force_update_loaded?: boolean;
   };
   const body: ReprocessOpts = await c.req
     .json<ReprocessOpts>()
@@ -552,6 +555,7 @@ adminAttending.openapi(reprocessRoute, async (c) => {
       refetchMissingBody: body.refetch_missing_body ?? true,
       limit: body.limit ?? 1000,
       dryRun: body.dry_run ?? false,
+      forceUpdateLoaded: body.force_update_loaded ?? false,
     });
     return c.json({
       status: 'completed' as const,
@@ -559,6 +563,7 @@ adminAttending.openapi(reprocessRoute, async (c) => {
       refetched: result.refetched,
       newly_parsed: result.newly_parsed,
       loaded: result.loaded,
+      updated_loaded: result.updated_loaded,
       failures: result.failures,
     });
   } catch (error) {

--- a/src/services/attending/extract.ts
+++ b/src/services/attending/extract.ts
@@ -320,7 +320,10 @@ function parseMessageCapture(msg: GmailMessage): ParsedGmailCandidate {
     } else if (vendor === 'ticketclub') {
       reservations = parseTicketClubHtml(html) ?? [];
     } else if (vendor === 'ticketmaster') {
-      reservations = parseTicketmasterHtml(html, msg.id) ?? [];
+      const internalDate = new Date(
+        parseInt(msg.internalDate, 10)
+      ).toISOString();
+      reservations = parseTicketmasterHtml(html, msg.id, internalDate) ?? [];
     } else if (vendor === 'axs') {
       reservations = parseAxsHtml(html) ?? [];
     } else if (vendor === 'vividseats') {

--- a/src/services/attending/parse-ticketmaster.test.ts
+++ b/src/services/attending/parse-ticketmaster.test.ts
@@ -109,6 +109,27 @@ describe('parseTicketmasterHtml', () => {
     });
   });
 
+  it('handles "X | vs. | Y" split across adjacent table cells', () => {
+    // Real-world bug from the prod data: the "X vs. Y" line ends up
+    // split across table cells in some Ticketmaster templates.
+    // After stripToText, the cells become separate lines, so the
+    // simple " vs. " regex doesn't match. Combine adjacent lines.
+    const html = `<html><body>
+<p>Ticketmaster</p>
+<p>The countdown to your event starts now. Save this info for your records.</p>
+<p>You Got the Tickets</p>
+<p>Order # 63-12852/SEA</p>
+<table><tr><td>Seattle Mariners</td><td>vs.</td><td>Los Angeles Angels</td></tr></table>
+<p>Wed &bull; Jul 24 2024 &bull; 7:10 PM</p>
+<p>T-Mobile Park, Seattle, WA</p>
+</body></html>`;
+    const result = parseTicketmasterHtml(html);
+    expect(result).not.toBeNull();
+    expect(result![0].event_name).toBe(
+      'Seattle Mariners vs. Los Angeles Angels'
+    );
+  });
+
   it('parses transfer-complete email without an Order#', () => {
     const html = `<html><body><pre>${TRANSFER_COMPLETE_TM_TEXT}</pre></body></html>`;
     const result = parseTicketmasterHtml(html, 'gmail-msg-abc123');

--- a/src/services/attending/parse-ticketmaster.ts
+++ b/src/services/attending/parse-ticketmaster.ts
@@ -34,7 +34,8 @@ import type { ParsedReservation, Vendor } from './parse-jsonld.js';
 
 export function parseTicketmasterHtml(
   html: string | null | undefined,
-  sourceRef?: string
+  sourceRef?: string,
+  messageDate?: string | null
 ): ParsedReservation[] | null {
   if (!html) return null;
   const text = stripToText(html);
@@ -50,7 +51,7 @@ export function parseTicketmasterHtml(
     /Transfer Status:\s*Completed/i.test(text) ||
     /successfully accepted your ticket transfer/i.test(text)
   ) {
-    return parseTicketmasterTransfer(text, sourceRef);
+    return parseTicketmasterTransfer(text, sourceRef, messageDate);
   }
 
   // Order number anchor — present in both layouts.
@@ -178,16 +179,24 @@ export function parseTicketmasterHtml(
  */
 function parseTicketmasterTransfer(
   text: string,
-  sourceRef: string | undefined
+  sourceRef: string | undefined,
+  messageDate: string | null | undefined
 ): ParsedReservation[] | null {
   const lines = text
     .split('\n')
     .map((s) => s.trim())
     .filter(Boolean);
 
-  // Year inference: prefer the copyright line, fall back to current year.
+  // Year inference: prefer the copyright line, then the email's
+  // internal_date (transfers usually arrive within ~2 weeks of the
+  // game), then current year as a final fallback. Without this,
+  // older transfer emails (no copyright string) inherit "today"
+  // and end up dated years in the future.
   const copyrightYear = matchSimple(text, /\(c\)\s*(\d{4})\s*Ticketmaster/i);
-  const inferredYear = copyrightYear ?? String(new Date().getFullYear());
+  const messageYear =
+    messageDate && /^\d{4}/.test(messageDate) ? messageDate.slice(0, 4) : null;
+  const inferredYear =
+    copyrightYear ?? messageYear ?? String(new Date().getFullYear());
 
   // Find "X vs. Y" line (event name).
   let eventName: string | null = null;

--- a/src/services/attending/parse-ticketmaster.ts
+++ b/src/services/attending/parse-ticketmaster.ts
@@ -94,12 +94,17 @@ export function parseTicketmasterHtml(
   // the strongest title candidate before falling back to the first
   // non-skipped line. This keeps email intros like "The countdown to
   // your event starts now…" from being mis-titled as the event.
+  //
+  // Also handle the table-cell-split case where the line list ends up
+  // ["Team A", "vs.", "Team B"] (each in its own <td>). Recombine
+  // adjacent triples into a single versus title before scanning.
+  const recombined = recombineSplitVersus(lines);
   let eventName = '';
   let eventStart: string | null = null;
   let dateLineIdx = -1;
   let versusCandidate: string | null = null;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (let i = 0; i < recombined.length; i++) {
+    const line = recombined[i];
     if (skipPattern.test(line)) continue;
     if (line.startsWith('$')) continue;
     if (/^\d+(?:[,.]\d+)?$/.test(line)) continue;
@@ -294,6 +299,47 @@ function parseTicketmasterTransferDate(
         ? 0
         : hour12;
   return `${year}-${mm}-${dd}T${String(hour24).padStart(2, '0')}:${String(min).padStart(2, '0')}`;
+}
+
+/**
+ * Some Ticketmaster templates put the team line in three separate
+ * <td>s — after stripToText that arrives as ["Seattle Mariners",
+ * "vs.", "Houston Astros"] (three lines). Detect that triple and
+ * collapse it to a single "X vs. Y" line so the versus heuristic
+ * picks it up. Same logic for the rare "vs"-only middle line.
+ */
+function recombineSplitVersus(lines: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (
+      i + 2 < lines.length &&
+      /^vs\.?$/i.test(lines[i + 1].trim()) &&
+      lines[i].length > 1 &&
+      lines[i + 2].length > 1 &&
+      !skipMidLine(lines[i]) &&
+      !skipMidLine(lines[i + 2])
+    ) {
+      out.push(`${lines[i]} vs. ${lines[i + 2]}`);
+      i += 2;
+      continue;
+    }
+    out.push(line);
+  }
+  return out;
+}
+
+function skipMidLine(s: string): boolean {
+  return (
+    /^\d/.test(s) ||
+    /^[$#@]/.test(s) ||
+    s.length > 100 ||
+    // Word-boundary anchors so "Seattle" doesn't match the "seat"
+    // alternation. The list catches structural rows in transfer
+    // emails — order numbers, section/row labels, ticket counts —
+    // that should not be treated as a team name.
+    /\b(?:order|section|row|seat|seats|total|ticket|tickets)\b/i.test(s)
+  );
 }
 
 function cleanVenueName(line: string): string {

--- a/src/services/attending/reprocess.ts
+++ b/src/services/attending/reprocess.ts
@@ -11,7 +11,10 @@
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import type { Database } from '../../db/client.js';
 import type { Env } from '../../types/env.js';
-import { attendedEventSources } from '../../db/schema/attending.js';
+import {
+  attendedEvents,
+  attendedEventSources,
+} from '../../db/schema/attending.js';
 import { getGoogleAccessToken } from '../google/auth.js';
 import { getGmailMessage, judgeSubject } from '../google/gmail-client.js';
 import { enrichCandidate } from './enrich.js';
@@ -34,6 +37,14 @@ export interface ReprocessOptions {
   refetchMissingBody?: boolean; // re-pull from Gmail when body_text/html absent
   limit?: number;
   dryRun?: boolean;
+  // When true, also reprocess source rows that already linked to an
+  // event AND overwrite the event's title/event_type when the new
+  // parse produces a confidently-better title (matches "X vs. Y").
+  // Use after a parser fix that changes title heuristics — earlier
+  // bad titles ("The countdown to your event…") get rewritten to
+  // the actual game line. Idempotent: re-running won't degrade good
+  // titles since the new parse won't differ.
+  forceUpdateLoaded?: boolean;
 }
 
 export interface ReprocessResult {
@@ -41,6 +52,7 @@ export interface ReprocessResult {
   refetched: number;
   newly_parsed: number;
   loaded: number;
+  updated_loaded: number;
   failures: Array<{ source_id: number; reason: string }>;
 }
 
@@ -54,12 +66,14 @@ export async function reprocessPendingSources(
     refetchMissingBody = true,
     limit = 1000,
     dryRun = false,
+    forceUpdateLoaded = false,
   } = opts;
   const result: ReprocessResult = {
     scanned: 0,
     refetched: 0,
     newly_parsed: 0,
     loaded: 0,
+    updated_loaded: 0,
     failures: [],
   };
 
@@ -77,7 +91,7 @@ export async function reprocessPendingSources(
       and(
         eq(attendedEventSources.userId, 1),
         eq(attendedEventSources.sourceType, 'gmail'),
-        isNull(attendedEventSources.eventId),
+        forceUpdateLoaded ? undefined : isNull(attendedEventSources.eventId),
         vendorClause
       )
     )
@@ -146,7 +160,12 @@ export async function reprocessPendingSources(
       } else if (senderVendor === 'ticketclub') {
         reservations = parseTicketClubHtml(html) ?? [];
       } else if (senderVendor === 'ticketmaster') {
-        reservations = parseTicketmasterHtml(html, row.sourceRef) ?? [];
+        reservations =
+          parseTicketmasterHtml(
+            html,
+            row.sourceRef,
+            (raw.internal_date as string) ?? null
+          ) ?? [];
       } else if (senderVendor === 'axs') {
         reservations = parseAxsHtml(html) ?? [];
       } else if (senderVendor === 'vividseats') {
@@ -162,6 +181,60 @@ export async function reprocessPendingSources(
     result.newly_parsed++;
 
     if (dryRun) continue;
+
+    // Force-update path: source row is already linked to an event,
+    // and the new parse produced a "X vs. Y" title that the existing
+    // event lacks. Overwrite title (and re-infer event_type from the
+    // new title via the enricher). No new event row created — we
+    // update in place, leave tickets/performers untouched.
+    if (forceUpdateLoaded && row.eventId != null) {
+      const newTitle = reservations[0].event_name;
+      const hasVersus =
+        newTitle != null && / vs\.? /i.test(newTitle) && newTitle.length > 5;
+      if (!hasVersus) continue;
+
+      const enrichedForType = await enrichCandidate(
+        {
+          source_ref: row.sourceRef,
+          source_type: 'gmail',
+          event_date: '2000-01-01',
+          event_datetime: null,
+          title: newTitle,
+          location: reservations[0].venue_address ?? reservations[0].venue_name,
+        },
+        db,
+        env
+      );
+      const newEventType = enrichedForType?.event_type ?? null;
+      const newCategory = enrichedForType?.category ?? null;
+
+      const [existingEvent] = await db
+        .select()
+        .from(attendedEvents)
+        .where(eq(attendedEvents.id, row.eventId));
+      if (!existingEvent) continue;
+
+      const existingHasVersus =
+        existingEvent.title != null && / vs\.? /i.test(existingEvent.title);
+
+      if (existingHasVersus) continue;
+
+      const usableCategory =
+        newCategory && newCategory !== 'unknown'
+          ? (newCategory as 'sports' | 'music' | 'arts')
+          : existingEvent.category;
+      await db
+        .update(attendedEvents)
+        .set({
+          title: newTitle,
+          eventType: newEventType ?? existingEvent.eventType,
+          category: usableCategory,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(eq(attendedEvents.id, row.eventId));
+      result.updated_loaded++;
+      continue;
+    }
 
     // Persist the new reservations on the source row, then enrich+load.
     raw.reservations = reservations;

--- a/src/services/attending/reprocess.ts
+++ b/src/services/attending/reprocess.ts
@@ -114,12 +114,18 @@ export async function reprocessPendingSources(
     const senderRaw = (raw.from as string) ?? '';
     result.scanned++;
 
-    // Re-fetch from Gmail if body data is missing.
-    if (
-      refetchMissingBody &&
-      (raw.body_text == null || raw.body_text === '') &&
-      (raw.body_html == null || raw.body_html === '')
-    ) {
+    // Re-fetch from Gmail if body data is missing or anemic.
+    // Older rows (pre-Phase-3.5) stored body_text but never body_html;
+    // some of those have a 14-char "Ticketmaster\n" stub that's
+    // technically non-empty but useless to vendor HTML parsers.
+    // Refetch when body_html is absent AND body_text is too short to
+    // be meaningful, OR when both are empty.
+    const textLen =
+      typeof raw.body_text === 'string' ? raw.body_text.length : 0;
+    const hasUsefulHtml =
+      typeof raw.body_html === 'string' && raw.body_html.length > 0;
+    const hasUsefulText = textLen >= 200;
+    if (refetchMissingBody && !hasUsefulHtml && !hasUsefulText) {
       try {
         if (!accessToken) accessToken = await getGoogleAccessToken(db, env);
         const msg = await getGmailMessage(accessToken, row.sourceRef);


### PR DESCRIPTION
## Summary

Three Mariners events (ids 104/106/107) stayed mis-titled through three rounds of fixes because their source rows have \`body_html=null\` and \`body_text="Ticketmaster\\n"\` (14 chars). The old refetch guard required BOTH bodies to be empty, so these rows slipped through every reprocess cycle — Ticketmaster's HTML parser saw a 14-char stub and bailed.

Tighten the guard: refetch whenever body_html is missing AND body_text is shorter than 200 chars. Real vendor confirmations are 2000+ chars; the threshold won't false-positive on legitimate text-only rows.

Confirmed via direct D1 query (\`wrangler d1 execute\`) that all three stuck rows fit this shape:
\`\`\`
id 63  → Mariners vs. Houston Astros        html_len=null  text_len=14
id 114 → Mariners vs. Toronto Blue Jays     html_len=null  text_len=14
id 126 → Mariners vs. Los Angeles Angels    html_len=null  text_len=14
\`\`\`

## Test plan

- [x] All 857 vitest cases pass
- [ ] Post-merge: re-run \`POST /v1/admin/attending/reprocess { force_update_loaded: true, refetch_missing_body: true, vendor: 'ticketmaster.com' }\` to refetch + re-parse + update those 3 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)