### PR TITLE
feat(attending): MLB box score enrichment + per-player stats

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -788,6 +788,88 @@
           }
         }
       },
+      "AttendingEnrichBoxScoresResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "enriched": {
+            "type": "integer"
+          },
+          "players_inserted": {
+            "type": "integer"
+          },
+          "players_updated": {
+            "type": "integer"
+          },
+          "appearances_inserted": {
+            "type": "integer"
+          },
+          "appearances_updated": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "event_id": {
+                  "type": "integer"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event_id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "enriched",
+          "players_inserted",
+          "players_updated",
+          "appearances_inserted",
+          "appearances_updated",
+          "failures"
+        ]
+      },
+      "AttendingEnrichBoxScoresBody": {
+        "type": "object",
+        "properties": {
+          "game_pks": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "skip_enriched": {
+            "type": "boolean",
+            "default": true
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100
+          },
+          "dry_run": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
       "SyncCompletedResponse": {
         "type": "object",
         "properties": {
@@ -20560,6 +20642,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingReprocessResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-boxscores": {
+      "post": {
+        "operationId": "adminAttendingEnrichBoxScores",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Backfill MLB box score data into attended events",
+        "description": "Pulls MLB Stats API box score + live feed for each attended MLB game, upserts every player who played, writes per-player appearance rows with batting/pitching lines, and merges game-level extras (attendance, weather, linescore, decisions) into attended_events.event_data. Idempotent — by default skips events already enriched. Use `skip_enriched: false` to force re-enrichment.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichBoxScoresBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Enrichment completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichBoxScoresResponse"
                 }
               }
             }

--- a/migrations/0034_attending_players.sql
+++ b/migrations/0034_attending_players.sql
@@ -1,0 +1,74 @@
+-- Players + per-game appearances for the attending domain.
+-- Modeled separately from `performers` (musical acts) because the
+-- schema diverges meaningfully — players have positions, jersey
+-- numbers, batting/pitching hands, debut dates.
+--
+-- Cross-source IDs:
+--   mlb_stats_id — MLB Stats API roster + boxscore endpoints
+--   espn_id      — ESPN game summary (resolved via name+jersey match)
+--
+-- Photos live in the shared `images` table, keyed on
+-- (domain='attending', entity_type='player_silo'|'player_full',
+-- entity_id=<players.id>). Both the MLB silo cutout and the ESPN
+-- full-body PNG are stored when both sources resolve.
+--
+-- attended_event_players holds one row per (event, player) appearance
+-- with batting/pitching/fielding lines as JSON. Capture-broadly bias —
+-- store full per-game stat lines so future UIs (year-in-review, hero
+-- stats, "best games I saw") can render whatever cut they need.
+
+CREATE TABLE IF NOT EXISTS players (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  user_id integer DEFAULT 1 NOT NULL,
+  league text NOT NULL,
+  mlb_stats_id integer,
+  espn_id text,
+  full_name text NOT NULL,
+  first_name text,
+  last_name text,
+  primary_position text,
+  primary_number text,
+  birth_date text,
+  birth_city text,
+  birth_country text,
+  bats text,
+  throws text,
+  primary_team_id integer,
+  debut_date text,
+  bio_data text,
+  created_at text NOT NULL,
+  updated_at text NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_players_league_mlb_stats_id
+  ON players (league, mlb_stats_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_players_league_espn_id
+  ON players (league, espn_id);
+CREATE INDEX IF NOT EXISTS idx_players_team ON players (primary_team_id);
+CREATE INDEX IF NOT EXISTS idx_players_last_name ON players (last_name);
+
+CREATE TABLE IF NOT EXISTS attended_event_players (
+  id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  user_id integer DEFAULT 1 NOT NULL,
+  event_id integer NOT NULL REFERENCES attended_events(id) ON DELETE CASCADE,
+  player_id integer NOT NULL REFERENCES players(id),
+  team_id integer,
+  is_home integer DEFAULT 0 NOT NULL,
+  batting_line text,
+  pitching_line text,
+  fielding_line text,
+  decision text,
+  notable integer DEFAULT 0 NOT NULL,
+  created_at text NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attended_event_players_unique
+  ON attended_event_players (event_id, player_id);
+CREATE INDEX IF NOT EXISTS idx_attended_event_players_event
+  ON attended_event_players (event_id);
+CREATE INDEX IF NOT EXISTS idx_attended_event_players_player
+  ON attended_event_players (player_id);
+CREATE INDEX IF NOT EXISTS idx_attended_event_players_decision
+  ON attended_event_players (decision);
+CREATE INDEX IF NOT EXISTS idx_attended_event_players_notable
+  ON attended_event_players (notable);

--- a/migrations/meta/0010_snapshot.json
+++ b/migrations/meta/0010_snapshot.json
@@ -1,0 +1,6546 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0d45a25b-ef69-410a-890a-d139220a2eda",
+  "prevId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "tables": {
+    "attended_event_performers": {
+      "name": "attended_event_performers",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performer_id": {
+          "name": "performer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'headliner'"
+        },
+        "billing_order": {
+          "name": "billing_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_attended_event_performers_performer": {
+          "name": "idx_attended_event_performers_performer",
+          "columns": [
+            "performer_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attended_event_performers_event_id_attended_events_id_fk": {
+          "name": "attended_event_performers_event_id_attended_events_id_fk",
+          "tableFrom": "attended_event_performers",
+          "tableTo": "attended_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attended_event_performers_performer_id_performers_id_fk": {
+          "name": "attended_event_performers_performer_id_performers_id_fk",
+          "tableFrom": "attended_event_performers",
+          "tableTo": "performers",
+          "columnsFrom": [
+            "performer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "attended_event_performers_event_id_performer_id_pk": {
+          "columns": [
+            "event_id",
+            "performer_id"
+          ],
+          "name": "attended_event_performers_event_id_performer_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attended_event_players": {
+      "name": "attended_event_players",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_home": {
+          "name": "is_home",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "batting_line": {
+          "name": "batting_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pitching_line": {
+          "name": "pitching_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fielding_line": {
+          "name": "fielding_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notable": {
+          "name": "notable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_attended_event_players_unique": {
+          "name": "idx_attended_event_players_unique",
+          "columns": [
+            "event_id",
+            "player_id"
+          ],
+          "isUnique": true
+        },
+        "idx_attended_event_players_event": {
+          "name": "idx_attended_event_players_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_event_players_player": {
+          "name": "idx_attended_event_players_player",
+          "columns": [
+            "player_id"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_event_players_decision": {
+          "name": "idx_attended_event_players_decision",
+          "columns": [
+            "decision"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_event_players_notable": {
+          "name": "idx_attended_event_players_notable",
+          "columns": [
+            "notable"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attended_event_players_event_id_attended_events_id_fk": {
+          "name": "attended_event_players_event_id_attended_events_id_fk",
+          "tableFrom": "attended_event_players",
+          "tableTo": "attended_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attended_event_players_player_id_players_id_fk": {
+          "name": "attended_event_players_player_id_players_id_fk",
+          "tableFrom": "attended_event_players",
+          "tableTo": "players",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attended_event_sources": {
+      "name": "attended_event_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_attended_event_sources_unique": {
+          "name": "idx_attended_event_sources_unique",
+          "columns": [
+            "source_type",
+            "source_ref"
+          ],
+          "isUnique": true
+        },
+        "idx_attended_event_sources_event": {
+          "name": "idx_attended_event_sources_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attended_event_sources_event_id_attended_events_id_fk": {
+          "name": "attended_event_sources_event_id_attended_events_id_fk",
+          "tableFrom": "attended_event_sources",
+          "tableTo": "attended_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attended_event_tickets": {
+      "name": "attended_event_tickets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row": {
+          "name": "row",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seat": {
+          "name": "seat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_price_cents": {
+          "name": "total_price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_attended_event_tickets_event": {
+          "name": "idx_attended_event_tickets_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_event_tickets_vendor": {
+          "name": "idx_attended_event_tickets_vendor",
+          "columns": [
+            "vendor"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_event_tickets_vendor_order": {
+          "name": "idx_attended_event_tickets_vendor_order",
+          "columns": [
+            "vendor",
+            "order_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "attended_event_tickets_event_id_attended_events_id_fk": {
+          "name": "attended_event_tickets_event_id_attended_events_id_fk",
+          "tableFrom": "attended_event_tickets",
+          "tableTo": "attended_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attended_events": {
+      "name": "attended_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_datetime": {
+          "name": "event_datetime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attended": {
+          "name": "attended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_attended_events_external": {
+          "name": "idx_attended_events_external",
+          "columns": [
+            "external_source",
+            "external_id"
+          ],
+          "isUnique": true
+        },
+        "idx_attended_events_user_date": {
+          "name": "idx_attended_events_user_date",
+          "columns": [
+            "user_id",
+            "event_date"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_events_type_date": {
+          "name": "idx_attended_events_type_date",
+          "columns": [
+            "event_type",
+            "event_date"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_events_category": {
+          "name": "idx_attended_events_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_events_venue": {
+          "name": "idx_attended_events_venue",
+          "columns": [
+            "venue_id"
+          ],
+          "isUnique": false
+        },
+        "idx_attended_events_series": {
+          "name": "idx_attended_events_series",
+          "columns": [
+            "series_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "attended_events_venue_id_venues_id_fk": {
+          "name": "attended_events_venue_id_venues_id_fk",
+          "tableFrom": "attended_events",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "performers": {
+      "name": "performers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performer_type": {
+          "name": "performer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'musical_artist'"
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastfm_artist_id": {
+          "name": "lastfm_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_performers_user_name_type": {
+          "name": "idx_performers_user_name_type",
+          "columns": [
+            "user_id",
+            "name",
+            "performer_type"
+          ],
+          "isUnique": true
+        },
+        "idx_performers_mbid": {
+          "name": "idx_performers_mbid",
+          "columns": [
+            "mbid"
+          ],
+          "isUnique": false
+        },
+        "idx_performers_lastfm_artist": {
+          "name": "idx_performers_lastfm_artist",
+          "columns": [
+            "lastfm_artist_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "performers_lastfm_artist_id_lastfm_artists_id_fk": {
+          "name": "performers_lastfm_artist_id_lastfm_artists_id_fk",
+          "tableFrom": "performers",
+          "tableTo": "lastfm_artists",
+          "columnsFrom": [
+            "lastfm_artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "players": {
+      "name": "players",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "league": {
+          "name": "league",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mlb_stats_id": {
+          "name": "mlb_stats_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "espn_id": {
+          "name": "espn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_position": {
+          "name": "primary_position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_number": {
+          "name": "primary_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_city": {
+          "name": "birth_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "birth_country": {
+          "name": "birth_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bats": {
+          "name": "bats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "throws": {
+          "name": "throws",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_team_id": {
+          "name": "primary_team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "debut_date": {
+          "name": "debut_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio_data": {
+          "name": "bio_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_players_league_mlb_stats_id": {
+          "name": "idx_players_league_mlb_stats_id",
+          "columns": [
+            "league",
+            "mlb_stats_id"
+          ],
+          "isUnique": true
+        },
+        "idx_players_league_espn_id": {
+          "name": "idx_players_league_espn_id",
+          "columns": [
+            "league",
+            "espn_id"
+          ],
+          "isUnique": true
+        },
+        "idx_players_team": {
+          "name": "idx_players_team",
+          "columns": [
+            "primary_team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_players_last_name": {
+          "name": "idx_players_last_name",
+          "columns": [
+            "last_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "venues": {
+      "name": "venues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_ids": {
+          "name": "external_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_venues_user_name": {
+          "name": "idx_venues_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_venues_city": {
+          "name": "idx_venues_city",
+          "columns": [
+            "city"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "collection_listening_xref": {
+      "name": "collection_listening_xref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastfm_album_name": {
+          "name": "lastfm_album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastfm_artist_name": {
+          "name": "lastfm_artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_played": {
+          "name": "last_played",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_collection_listening_xref_unique": {
+          "name": "idx_collection_listening_xref_unique",
+          "columns": [
+            "user_id",
+            "collection_id"
+          ],
+          "isUnique": true
+        },
+        "idx_collection_listening_xref_release": {
+          "name": "idx_collection_listening_xref_release",
+          "columns": [
+            "release_id"
+          ],
+          "isUnique": false
+        },
+        "idx_collection_listening_xref_play_count": {
+          "name": "idx_collection_listening_xref_play_count",
+          "columns": [
+            "play_count"
+          ],
+          "isUnique": false
+        },
+        "idx_collection_listening_xref_user_id": {
+          "name": "idx_collection_listening_xref_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "collection_listening_xref_collection_id_discogs_collection_id_fk": {
+          "name": "collection_listening_xref_collection_id_discogs_collection_id_fk",
+          "tableFrom": "collection_listening_xref",
+          "tableTo": "discogs_collection",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_listening_xref_release_id_discogs_releases_id_fk": {
+          "name": "collection_listening_xref_release_id_discogs_releases_id_fk",
+          "tableFrom": "collection_listening_xref",
+          "tableTo": "discogs_releases",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discogs_artists": {
+      "name": "discogs_artists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "discogs_id": {
+          "name": "discogs_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discogs_artists_discogs_id": {
+          "name": "idx_discogs_artists_discogs_id",
+          "columns": [
+            "user_id",
+            "discogs_id"
+          ],
+          "isUnique": true
+        },
+        "idx_discogs_artists_name": {
+          "name": "idx_discogs_artists_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "idx_discogs_artists_user_id": {
+          "name": "idx_discogs_artists_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discogs_collection": {
+      "name": "discogs_collection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discogs_collection_instance": {
+          "name": "idx_discogs_collection_instance",
+          "columns": [
+            "user_id",
+            "instance_id"
+          ],
+          "isUnique": true
+        },
+        "idx_discogs_collection_release": {
+          "name": "idx_discogs_collection_release",
+          "columns": [
+            "release_id"
+          ],
+          "isUnique": false
+        },
+        "idx_discogs_collection_date_added": {
+          "name": "idx_discogs_collection_date_added",
+          "columns": [
+            "date_added"
+          ],
+          "isUnique": false
+        },
+        "idx_discogs_collection_user_id": {
+          "name": "idx_discogs_collection_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "discogs_collection_release_id_discogs_releases_id_fk": {
+          "name": "discogs_collection_release_id_discogs_releases_id_fk",
+          "tableFrom": "discogs_collection",
+          "tableTo": "discogs_releases",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discogs_collection_stats": {
+      "name": "discogs_collection_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "by_format": {
+          "name": "by_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wantlist_count": {
+          "name": "wantlist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_artists": {
+          "name": "unique_artists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value": {
+          "name": "estimated_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_genre": {
+          "name": "top_genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oldest_release_year": {
+          "name": "oldest_release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newest_release_year": {
+          "name": "newest_release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "most_collected_artist": {
+          "name": "most_collected_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_this_year": {
+          "name": "added_this_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "by_genre": {
+          "name": "by_genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "by_decade": {
+          "name": "by_decade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discogs_collection_stats_user": {
+          "name": "idx_discogs_collection_stats_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discogs_release_artists": {
+      "name": "discogs_release_artists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discogs_release_artists_unique": {
+          "name": "idx_discogs_release_artists_unique",
+          "columns": [
+            "release_id",
+            "artist_id"
+          ],
+          "isUnique": true
+        },
+        "idx_discogs_release_artists_artist": {
+          "name": "idx_discogs_release_artists_artist",
+          "columns": [
+            "artist_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "discogs_release_artists_release_id_discogs_releases_id_fk": {
+          "name": "discogs_release_artists_release_id_discogs_releases_id_fk",
+          "tableFrom": "discogs_release_artists",
+          "tableTo": "discogs_releases",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "discogs_release_artists_artist_id_discogs_artists_id_fk": {
+          "name": "discogs_release_artists_artist_id_discogs_artists_id_fk",
+          "tableFrom": "discogs_release_artists",
+          "tableTo": "discogs_artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discogs_releases": {
+      "name": "discogs_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "discogs_id": {
+          "name": "discogs_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb_url": {
+          "name": "thumb_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "styles": {
+          "name": "styles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "formats": {
+          "name": "formats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "format_details": {
+          "name": "format_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tracklist": {
+          "name": "tracklist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_have": {
+          "name": "community_have",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_want": {
+          "name": "community_want",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lowest_price": {
+          "name": "lowest_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_for_sale": {
+          "name": "num_for_sale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discogs_releases_discogs_id": {
+          "name": "idx_discogs_releases_discogs_id",
+          "columns": [
+            "user_id",
+            "discogs_id"
+          ],
+          "isUnique": true
+        },
+        "idx_discogs_releases_year": {
+          "name": "idx_discogs_releases_year",
+          "columns": [
+            "year"
+          ],
+          "isUnique": false
+        },
+        "idx_discogs_releases_user_id": {
+          "name": "idx_discogs_releases_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "discogs_wantlist": {
+      "name": "discogs_wantlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "discogs_id": {
+          "name": "discogs_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artists": {
+          "name": "artists",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb_url": {
+          "name": "thumb_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discogs_url": {
+          "name": "discogs_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "formats": {
+          "name": "formats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "date_added": {
+          "name": "date_added",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_discogs_wantlist_discogs_id": {
+          "name": "idx_discogs_wantlist_discogs_id",
+          "columns": [
+            "user_id",
+            "discogs_id"
+          ],
+          "isUnique": true
+        },
+        "idx_discogs_wantlist_date_added": {
+          "name": "idx_discogs_wantlist_date_added",
+          "columns": [
+            "date_added"
+          ],
+          "isUnique": false
+        },
+        "idx_discogs_wantlist_user_id": {
+          "name": "idx_discogs_wantlist_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "google_tokens": {
+      "name": "google_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_google_tokens_user_id": {
+          "name": "idx_google_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_albums": {
+      "name": "lastfm_albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playcount": {
+          "name": "playcount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_filtered": {
+          "name": "is_filtered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_compilation": {
+          "name": "is_compilation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itunes_enriched_at": {
+          "name": "itunes_enriched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_albums_unique": {
+          "name": "idx_lastfm_albums_unique",
+          "columns": [
+            "name",
+            "artist_id"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_albums_artist_id": {
+          "name": "idx_lastfm_albums_artist_id",
+          "columns": [
+            "artist_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_albums_user_id": {
+          "name": "idx_lastfm_albums_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_albums_filtered": {
+          "name": "idx_lastfm_albums_filtered",
+          "columns": [
+            "is_filtered"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_albums_compilation": {
+          "name": "idx_lastfm_albums_compilation",
+          "columns": [
+            "is_compilation",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lastfm_albums_artist_id_lastfm_artists_id_fk": {
+          "name": "lastfm_albums_artist_id_lastfm_artists_id_fk",
+          "tableFrom": "lastfm_albums",
+          "tableTo": "lastfm_artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_artists": {
+      "name": "lastfm_artists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playcount": {
+          "name": "playcount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_filtered": {
+          "name": "is_filtered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itunes_enriched_at": {
+          "name": "itunes_enriched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_artists_user_name": {
+          "name": "idx_lastfm_artists_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_artists_user_id": {
+          "name": "idx_lastfm_artists_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_artists_filtered": {
+          "name": "idx_lastfm_artists_filtered",
+          "columns": [
+            "is_filtered"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_artists_genre": {
+          "name": "idx_lastfm_artists_genre",
+          "columns": [
+            "genre"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_filters": {
+      "name": "lastfm_filters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_filters_type": {
+          "name": "idx_lastfm_filters_type",
+          "columns": [
+            "filter_type"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_filters_user_id": {
+          "name": "idx_lastfm_filters_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_monthly_stats": {
+      "name": "lastfm_monthly_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "year_month": {
+          "name": "year_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scrobbles": {
+          "name": "scrobbles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_artists": {
+          "name": "unique_artists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_albums": {
+          "name": "unique_albums",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_monthly_stats_unique": {
+          "name": "idx_lastfm_monthly_stats_unique",
+          "columns": [
+            "user_id",
+            "year_month"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_monthly_stats_user_id": {
+          "name": "idx_lastfm_monthly_stats_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_scrobbles": {
+      "name": "lastfm_scrobbles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scrobbled_at": {
+          "name": "scrobbled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_scrobbles_track_id": {
+          "name": "idx_lastfm_scrobbles_track_id",
+          "columns": [
+            "track_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_scrobbles_scrobbled_at": {
+          "name": "idx_lastfm_scrobbles_scrobbled_at",
+          "columns": [
+            "scrobbled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_scrobbles_user_id": {
+          "name": "idx_lastfm_scrobbles_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_scrobbles_track_scrobbled": {
+          "name": "idx_lastfm_scrobbles_track_scrobbled",
+          "columns": [
+            "track_id",
+            "scrobbled_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lastfm_scrobbles_track_id_lastfm_tracks_id_fk": {
+          "name": "lastfm_scrobbles_track_id_lastfm_tracks_id_fk",
+          "tableFrom": "lastfm_scrobbles",
+          "tableTo": "lastfm_tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_top_albums": {
+      "name": "lastfm_top_albums",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playcount": {
+          "name": "playcount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_top_albums_unique": {
+          "name": "idx_lastfm_top_albums_unique",
+          "columns": [
+            "period",
+            "album_id"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_top_albums_period": {
+          "name": "idx_lastfm_top_albums_period",
+          "columns": [
+            "period"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_top_albums_user_id": {
+          "name": "idx_lastfm_top_albums_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lastfm_top_albums_album_id_lastfm_albums_id_fk": {
+          "name": "lastfm_top_albums_album_id_lastfm_albums_id_fk",
+          "tableFrom": "lastfm_top_albums",
+          "tableTo": "lastfm_albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_top_artists": {
+      "name": "lastfm_top_artists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playcount": {
+          "name": "playcount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_top_artists_unique": {
+          "name": "idx_lastfm_top_artists_unique",
+          "columns": [
+            "period",
+            "artist_id"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_top_artists_period": {
+          "name": "idx_lastfm_top_artists_period",
+          "columns": [
+            "period"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_top_artists_user_id": {
+          "name": "idx_lastfm_top_artists_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lastfm_top_artists_artist_id_lastfm_artists_id_fk": {
+          "name": "lastfm_top_artists_artist_id_lastfm_artists_id_fk",
+          "tableFrom": "lastfm_top_artists",
+          "tableTo": "lastfm_artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_top_tracks": {
+      "name": "lastfm_top_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "playcount": {
+          "name": "playcount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_top_tracks_unique": {
+          "name": "idx_lastfm_top_tracks_unique",
+          "columns": [
+            "period",
+            "track_id"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_top_tracks_period": {
+          "name": "idx_lastfm_top_tracks_period",
+          "columns": [
+            "period"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_top_tracks_user_id": {
+          "name": "idx_lastfm_top_tracks_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lastfm_top_tracks_track_id_lastfm_tracks_id_fk": {
+          "name": "lastfm_top_tracks_track_id_lastfm_tracks_id_fk",
+          "tableFrom": "lastfm_top_tracks",
+          "tableTo": "lastfm_tracks",
+          "columnsFrom": [
+            "track_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_tracks": {
+      "name": "lastfm_tracks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_filtered": {
+          "name": "is_filtered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "apple_music_id": {
+          "name": "apple_music_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "apple_music_url": {
+          "name": "apple_music_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "itunes_enriched_at": {
+          "name": "itunes_enriched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_tracks_unique": {
+          "name": "idx_lastfm_tracks_unique",
+          "columns": [
+            "name",
+            "artist_id"
+          ],
+          "isUnique": true
+        },
+        "idx_lastfm_tracks_artist_id": {
+          "name": "idx_lastfm_tracks_artist_id",
+          "columns": [
+            "artist_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_tracks_album_id": {
+          "name": "idx_lastfm_tracks_album_id",
+          "columns": [
+            "album_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_tracks_user_id": {
+          "name": "idx_lastfm_tracks_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_lastfm_tracks_filtered": {
+          "name": "idx_lastfm_tracks_filtered",
+          "columns": [
+            "is_filtered"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "lastfm_tracks_artist_id_lastfm_artists_id_fk": {
+          "name": "lastfm_tracks_artist_id_lastfm_artists_id_fk",
+          "tableFrom": "lastfm_tracks",
+          "tableTo": "lastfm_artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lastfm_tracks_album_id_lastfm_albums_id_fk": {
+          "name": "lastfm_tracks_album_id_lastfm_albums_id_fk",
+          "tableFrom": "lastfm_tracks",
+          "tableTo": "lastfm_albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lastfm_user_stats": {
+      "name": "lastfm_user_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_scrobbles": {
+          "name": "total_scrobbles",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_artists": {
+          "name": "unique_artists",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_albums": {
+          "name": "unique_albums",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "unique_tracks": {
+          "name": "unique_tracks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "registered_date": {
+          "name": "registered_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_lastfm_user_stats_user_id": {
+          "name": "idx_lastfm_user_stats_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reading_highlights": {
+      "name": "reading_highlights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chapter": {
+          "name": "chapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reading_highlights_source_unique": {
+          "name": "idx_reading_highlights_source_unique",
+          "columns": [
+            "source_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_reading_highlights_item": {
+          "name": "idx_reading_highlights_item",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_highlights_user": {
+          "name": "idx_reading_highlights_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_highlights_created": {
+          "name": "idx_reading_highlights_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reading_highlights_item_id_reading_items_id_fk": {
+          "name": "reading_highlights_item_id_reading_items_id_fk",
+          "tableFrom": "reading_highlights",
+          "tableTo": "reading_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reading_items": {
+      "name": "reading_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'article'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'instapaper'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body_excerpt": {
+          "name": "body_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_read_min": {
+          "name": "estimated_read_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image_url": {
+          "name": "og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_description": {
+          "name": "og_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "article_tags": {
+          "name": "article_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "enrichment_error": {
+          "name": "enrichment_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unread'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress_updated_at": {
+          "name": "progress_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_reading_items_source_unique": {
+          "name": "idx_reading_items_source_unique",
+          "columns": [
+            "source",
+            "source_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_reading_items_user_status": {
+          "name": "idx_reading_items_user_status",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_items_user_type": {
+          "name": "idx_reading_items_user_type",
+          "columns": [
+            "user_id",
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_items_saved_at": {
+          "name": "idx_reading_items_saved_at",
+          "columns": [
+            "saved_at"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_items_finished_at": {
+          "name": "idx_reading_items_finished_at",
+          "columns": [
+            "finished_at"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_items_domain": {
+          "name": "idx_reading_items_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "idx_reading_items_source": {
+          "name": "idx_reading_items_source",
+          "columns": [
+            "source",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_activities": {
+      "name": "strava_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "strava_id": {
+          "name": "strava_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sport_type": {
+          "name": "sport_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Run'"
+        },
+        "workout_type": {
+          "name": "workout_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "distance_meters": {
+          "name": "distance_meters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "moving_time_seconds": {
+          "name": "moving_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "elapsed_time_seconds": {
+          "name": "elapsed_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_elevation_gain_meters": {
+          "name": "total_elevation_gain_meters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_elevation_gain_feet": {
+          "name": "total_elevation_gain_feet",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date_local": {
+          "name": "start_date_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lat": {
+          "name": "start_lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_lng": {
+          "name": "start_lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_speed_ms": {
+          "name": "average_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_speed_ms": {
+          "name": "max_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pace_min_per_mile": {
+          "name": "pace_min_per_mile",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pace_formatted": {
+          "name": "pace_formatted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_heartrate": {
+          "name": "average_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_heartrate": {
+          "name": "max_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_cadence": {
+          "name": "average_cadence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calories": {
+          "name": "calories",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "suffer_score": {
+          "name": "suffer_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_polyline": {
+          "name": "map_polyline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gear_id": {
+          "name": "gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "achievement_count": {
+          "name": "achievement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "pr_count": {
+          "name": "pr_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_race": {
+          "name": "is_race",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "strava_url": {
+          "name": "strava_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_activities_user_strava": {
+          "name": "idx_strava_activities_user_strava",
+          "columns": [
+            "user_id",
+            "strava_id"
+          ],
+          "isUnique": true
+        },
+        "idx_strava_activities_user_id": {
+          "name": "idx_strava_activities_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_activities_start_date": {
+          "name": "idx_strava_activities_start_date",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_activities_city": {
+          "name": "idx_strava_activities_city",
+          "columns": [
+            "city"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_activities_gear_id": {
+          "name": "idx_strava_activities_gear_id",
+          "columns": [
+            "gear_id"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_activities_workout_type": {
+          "name": "idx_strava_activities_workout_type",
+          "columns": [
+            "workout_type"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_activities_is_deleted": {
+          "name": "idx_strava_activities_is_deleted",
+          "columns": [
+            "is_deleted"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_gear": {
+      "name": "strava_gear",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "strava_gear_id": {
+          "name": "strava_gear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_meters": {
+          "name": "distance_meters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_retired": {
+          "name": "is_retired",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_gear_strava_gear_id": {
+          "name": "idx_strava_gear_strava_gear_id",
+          "columns": [
+            "strava_gear_id"
+          ],
+          "isUnique": true
+        },
+        "idx_strava_gear_user_id": {
+          "name": "idx_strava_gear_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_lifetime_stats": {
+      "name": "strava_lifetime_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_distance_miles": {
+          "name": "total_distance_miles",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_elevation_feet": {
+          "name": "total_elevation_feet",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_pace_formatted": {
+          "name": "avg_pace_formatted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "years_active": {
+          "name": "years_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "first_run": {
+          "name": "first_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eddington_number": {
+          "name": "eddington_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_streak_days": {
+          "name": "current_streak_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_streak_start": {
+          "name": "current_streak_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_streak_end": {
+          "name": "current_streak_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longest_streak_days": {
+          "name": "longest_streak_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "longest_streak_start": {
+          "name": "longest_streak_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longest_streak_end": {
+          "name": "longest_streak_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_lifetime_stats_user_id": {
+          "name": "idx_strava_lifetime_stats_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_personal_records": {
+      "name": "strava_personal_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "distance": {
+          "name": "distance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_label": {
+          "name": "distance_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_seconds": {
+          "name": "time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "time_formatted": {
+          "name": "time_formatted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pace_formatted": {
+          "name": "pace_formatted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_strava_id": {
+          "name": "activity_strava_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_name": {
+          "name": "activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_prs_unique": {
+          "name": "idx_strava_prs_unique",
+          "columns": [
+            "user_id",
+            "distance"
+          ],
+          "isUnique": true
+        },
+        "idx_strava_prs_user_id": {
+          "name": "idx_strava_prs_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_splits": {
+      "name": "strava_splits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "activity_strava_id": {
+          "name": "activity_strava_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "split_number": {
+          "name": "split_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_meters": {
+          "name": "distance_meters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "distance_miles": {
+          "name": "distance_miles",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moving_time_seconds": {
+          "name": "moving_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elapsed_time_seconds": {
+          "name": "elapsed_time_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "elevation_difference_meters": {
+          "name": "elevation_difference_meters",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "elevation_difference_feet": {
+          "name": "elevation_difference_feet",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_speed_ms": {
+          "name": "average_speed_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pace_min_per_mile": {
+          "name": "pace_min_per_mile",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pace_formatted": {
+          "name": "pace_formatted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_heartrate": {
+          "name": "average_heartrate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "average_cadence": {
+          "name": "average_cadence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_splits_activity": {
+          "name": "idx_strava_splits_activity",
+          "columns": [
+            "activity_strava_id"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_splits_user_id": {
+          "name": "idx_strava_splits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_strava_splits_user_activity": {
+          "name": "idx_strava_splits_user_activity",
+          "columns": [
+            "user_id",
+            "activity_strava_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_tokens": {
+      "name": "strava_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_tokens_user_id": {
+          "name": "idx_strava_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "strava_year_summaries": {
+      "name": "strava_year_summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_distance_miles": {
+          "name": "total_distance_miles",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_elevation_feet": {
+          "name": "total_elevation_feet",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_pace_formatted": {
+          "name": "avg_pace_formatted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longest_run_miles": {
+          "name": "longest_run_miles",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "race_count": {
+          "name": "race_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_strava_year_summaries_unique": {
+          "name": "idx_strava_year_summaries_unique",
+          "columns": [
+            "user_id",
+            "year"
+          ],
+          "isUnique": true
+        },
+        "idx_strava_year_summaries_user_id": {
+          "name": "idx_strava_year_summaries_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_feed": {
+      "name": "activity_feed",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_activity_feed_domain": {
+          "name": "idx_activity_feed_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_feed_occurred_at": {
+          "name": "idx_activity_feed_occurred_at",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_feed_event_type": {
+          "name": "idx_activity_feed_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_feed_user_id": {
+          "name": "idx_activity_feed_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hint": {
+          "name": "key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'read'"
+        },
+        "rate_limit_rpm": {
+          "name": "rate_limit_rpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_api_keys_key_hash": {
+          "name": "idx_api_keys_key_hash",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_api_keys_user_id": {
+          "name": "idx_api_keys_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbhash": {
+          "name": "thumbhash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dominant_color": {
+          "name": "dominant_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accent_color": {
+          "name": "accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "override_at": {
+          "name": "override_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_version": {
+          "name": "image_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "search_hints": {
+          "name": "search_hints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_images_unique": {
+          "name": "idx_images_unique",
+          "columns": [
+            "domain",
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": true
+        },
+        "idx_images_domain": {
+          "name": "idx_images_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "idx_images_entity": {
+          "name": "idx_images_entity",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "idx_images_user_id": {
+          "name": "idx_images_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "revalidation_hooks": {
+      "name": "revalidation_hooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_revalidation_hooks_user_id": {
+          "name": "idx_revalidation_hooks_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_runs": {
+      "name": "sync_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "items_synced": {
+          "name": "items_synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_sync_runs_domain": {
+          "name": "idx_sync_runs_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "idx_sync_runs_started_at": {
+          "name": "idx_sync_runs_started_at",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sync_runs_user_id": {
+          "name": "idx_sync_runs_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_events": {
+      "name": "webhook_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_source": {
+          "name": "event_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_title": {
+          "name": "account_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_events_unique": {
+          "name": "idx_webhook_events_unique",
+          "columns": [
+            "event_source",
+            "event_id"
+          ],
+          "isUnique": true
+        },
+        "idx_webhook_events_source": {
+          "name": "idx_webhook_events_source",
+          "columns": [
+            "event_source"
+          ],
+          "isUnique": false
+        },
+        "idx_webhook_events_user_id": {
+          "name": "idx_webhook_events_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trakt_collection": {
+      "name": "trakt_collection",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trakt_id": {
+          "name": "trakt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hdr": {
+          "name": "hdr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio": {
+          "name": "audio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collected_at": {
+          "name": "collected_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trakt_collection_unique": {
+          "name": "idx_trakt_collection_unique",
+          "columns": [
+            "user_id",
+            "trakt_id",
+            "media_type"
+          ],
+          "isUnique": true
+        },
+        "idx_trakt_collection_movie": {
+          "name": "idx_trakt_collection_movie",
+          "columns": [
+            "movie_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trakt_collection_media_type": {
+          "name": "idx_trakt_collection_media_type",
+          "columns": [
+            "media_type"
+          ],
+          "isUnique": false
+        },
+        "idx_trakt_collection_collected_at": {
+          "name": "idx_trakt_collection_collected_at",
+          "columns": [
+            "collected_at"
+          ],
+          "isUnique": false
+        },
+        "idx_trakt_collection_user_id": {
+          "name": "idx_trakt_collection_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "trakt_collection_movie_id_movies_id_fk": {
+          "name": "trakt_collection_movie_id_movies_id_fk",
+          "tableFrom": "trakt_collection",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trakt_collection_stats": {
+      "name": "trakt_collection_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "by_format": {
+          "name": "by_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "by_resolution": {
+          "name": "by_resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "by_hdr": {
+          "name": "by_hdr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "by_genre": {
+          "name": "by_genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "by_decade": {
+          "name": "by_decade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_this_year": {
+          "name": "added_this_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trakt_collection_stats_user": {
+          "name": "idx_trakt_collection_stats_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trakt_tokens": {
+      "name": "trakt_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_trakt_tokens_user_id": {
+          "name": "idx_trakt_tokens_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "directors": {
+      "name": "directors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "directors_name_unique": {
+          "name": "directors_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "genres": {
+      "name": "genres",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_directors": {
+      "name": "movie_directors",
+      "columns": {
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "director_id": {
+          "name": "director_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_movie_directors_director_id": {
+          "name": "idx_movie_directors_director_id",
+          "columns": [
+            "director_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "movie_directors_movie_id_movies_id_fk": {
+          "name": "movie_directors_movie_id_movies_id_fk",
+          "tableFrom": "movie_directors",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_directors_director_id_directors_id_fk": {
+          "name": "movie_directors_director_id_directors_id_fk",
+          "tableFrom": "movie_directors",
+          "tableTo": "directors",
+          "columnsFrom": [
+            "director_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "movie_directors_movie_id_director_id_pk": {
+          "columns": [
+            "movie_id",
+            "director_id"
+          ],
+          "name": "movie_directors_movie_id_director_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movie_genres": {
+      "name": "movie_genres",
+      "columns": {
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_movie_genres_genre_id": {
+          "name": "idx_movie_genres_genre_id",
+          "columns": [
+            "genre_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "movie_genres_movie_id_movies_id_fk": {
+          "name": "movie_genres_movie_id_movies_id_fk",
+          "tableFrom": "movie_genres",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movie_genres_genre_id_genres_id_fk": {
+          "name": "movie_genres_genre_id_genres_id_fk",
+          "tableFrom": "movie_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "movie_genres_movie_id_genre_id_pk": {
+          "columns": [
+            "movie_id",
+            "genre_id"
+          ],
+          "name": "movie_genres_movie_id_genre_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movies": {
+      "name": "movies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imdb_id": {
+          "name": "imdb_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_rating": {
+          "name": "content_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime": {
+          "name": "runtime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_rating": {
+          "name": "tmdb_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "movies_plex_rating_key_unique": {
+          "name": "movies_plex_rating_key_unique",
+          "columns": [
+            "plex_rating_key"
+          ],
+          "isUnique": true
+        },
+        "movies_tmdb_id_unique": {
+          "name": "movies_tmdb_id_unique",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": true
+        },
+        "movies_imdb_id_unique": {
+          "name": "movies_imdb_id_unique",
+          "columns": [
+            "imdb_id"
+          ],
+          "isUnique": true
+        },
+        "idx_movies_year": {
+          "name": "idx_movies_year",
+          "columns": [
+            "year"
+          ],
+          "isUnique": false
+        },
+        "idx_movies_tmdb_id": {
+          "name": "idx_movies_tmdb_id",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": false
+        },
+        "idx_movies_user_id": {
+          "name": "idx_movies_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_episodes_watched": {
+      "name": "plex_episodes_watched",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "show_id": {
+          "name": "show_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "season_number": {
+          "name": "season_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "episode_number": {
+          "name": "episode_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_plex_episodes_watched_show_id": {
+          "name": "idx_plex_episodes_watched_show_id",
+          "columns": [
+            "show_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plex_episodes_watched_watched_at": {
+          "name": "idx_plex_episodes_watched_watched_at",
+          "columns": [
+            "watched_at"
+          ],
+          "isUnique": false
+        },
+        "idx_plex_episodes_watched_user_id": {
+          "name": "idx_plex_episodes_watched_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plex_episodes_timeline": {
+          "name": "idx_plex_episodes_timeline",
+          "columns": [
+            "user_id",
+            "watched_at"
+          ],
+          "isUnique": false
+        },
+        "idx_plex_episodes_unique": {
+          "name": "idx_plex_episodes_unique",
+          "columns": [
+            "show_id",
+            "season_number",
+            "episode_number",
+            "watched_at"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "plex_episodes_watched_show_id_plex_shows_id_fk": {
+          "name": "plex_episodes_watched_show_id_plex_shows_id_fk",
+          "tableFrom": "plex_episodes_watched",
+          "tableTo": "plex_shows",
+          "columnsFrom": [
+            "show_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_shows": {
+      "name": "plex_shows",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "plex_rating_key": {
+          "name": "plex_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_id": {
+          "name": "tmdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "poster_path": {
+          "name": "poster_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backdrop_path": {
+          "name": "backdrop_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_rating": {
+          "name": "content_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tmdb_rating": {
+          "name": "tmdb_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_seasons": {
+          "name": "total_seasons",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_episodes": {
+          "name": "total_episodes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plex_shows_plex_rating_key_unique": {
+          "name": "plex_shows_plex_rating_key_unique",
+          "columns": [
+            "plex_rating_key"
+          ],
+          "isUnique": true
+        },
+        "idx_plex_shows_user_id": {
+          "name": "idx_plex_shows_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_plex_shows_tmdb_id": {
+          "name": "idx_plex_shows_tmdb_id",
+          "columns": [
+            "tmdb_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watch_history": {
+      "name": "watch_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "movie_id": {
+          "name": "movie_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "watched_at": {
+          "name": "watched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'plex'"
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "percent_complete": {
+          "name": "percent_complete",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rewatch": {
+          "name": "rewatch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_url": {
+          "name": "review_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "letterboxd_guid": {
+          "name": "letterboxd_guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_watch_history_movie_id": {
+          "name": "idx_watch_history_movie_id",
+          "columns": [
+            "movie_id"
+          ],
+          "isUnique": false
+        },
+        "idx_watch_history_watched_at": {
+          "name": "idx_watch_history_watched_at",
+          "columns": [
+            "watched_at"
+          ],
+          "isUnique": false
+        },
+        "idx_watch_history_user_id": {
+          "name": "idx_watch_history_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_watch_history_source": {
+          "name": "idx_watch_history_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "idx_watch_history_movie_watched": {
+          "name": "idx_watch_history_movie_watched",
+          "columns": [
+            "movie_id",
+            "watched_at"
+          ],
+          "isUnique": false
+        },
+        "idx_watch_history_letterboxd_guid": {
+          "name": "idx_watch_history_letterboxd_guid",
+          "columns": [
+            "letterboxd_guid"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "watch_history_movie_id_movies_id_fk": {
+          "name": "watch_history_movie_id_movies_id_fk",
+          "tableFrom": "watch_history",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movie_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "watch_stats": {
+      "name": "watch_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "total_movies": {
+          "name": "total_movies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_watch_time_s": {
+          "name": "total_watch_time_s",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "movies_this_year": {
+          "name": "movies_this_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_shows": {
+          "name": "total_shows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_episodes_watched": {
+          "name": "total_episodes_watched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "episodes_this_year": {
+          "name": "episodes_this_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_watch_stats_user_id": {
+          "name": "idx_watch_stats_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1773350400000,
       "tag": "0009_trakt_collection",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1777207414393,
+      "tag": "0034_attending_players",
+      "breakpoints": true
     }
   ]
 }

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -788,6 +788,88 @@
           }
         }
       },
+      "AttendingEnrichBoxScoresResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "enriched": {
+            "type": "integer"
+          },
+          "players_inserted": {
+            "type": "integer"
+          },
+          "players_updated": {
+            "type": "integer"
+          },
+          "appearances_inserted": {
+            "type": "integer"
+          },
+          "appearances_updated": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "event_id": {
+                  "type": "integer"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event_id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "enriched",
+          "players_inserted",
+          "players_updated",
+          "appearances_inserted",
+          "appearances_updated",
+          "failures"
+        ]
+      },
+      "AttendingEnrichBoxScoresBody": {
+        "type": "object",
+        "properties": {
+          "game_pks": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "skip_enriched": {
+            "type": "boolean",
+            "default": true
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100
+          },
+          "dry_run": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
       "SyncCompletedResponse": {
         "type": "object",
         "properties": {
@@ -20560,6 +20642,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingReprocessResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-boxscores": {
+      "post": {
+        "operationId": "adminAttendingEnrichBoxScores",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Backfill MLB box score data into attended events",
+        "description": "Pulls MLB Stats API box score + live feed for each attended MLB game, upserts every player who played, writes per-player appearance rows with batting/pitching lines, and merges game-level extras (attendance, weather, linescore, decisions) into attended_events.event_data. Idempotent — by default skips events already enriched. Use `skip_enriched: false` to force re-enrichment.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichBoxScoresBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Enrichment completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichBoxScoresResponse"
                 }
               }
             }

--- a/src/db/schema/attending.ts
+++ b/src/db/schema/attending.ts
@@ -249,3 +249,93 @@ export const attendedEventSources = sqliteTable(
     index('idx_attended_event_sources_event').on(table.eventId),
   ]
 );
+
+// Players: the people on the field/court for sports events I attended.
+// Modeled separately from `performers` (musical artists/comedians) because
+// the schema is genuinely different — players have positions, jersey
+// numbers, batting/pitching hands, debut dates. Cross-source IDs:
+// `mlbStatsId` from the MLB Stats API roster + boxscore endpoints,
+// `espnId` from ESPN game summaries (resolved via name+jersey match).
+//
+// Photos live in the shared `images` table keyed on
+// (domain='attending', entity_type='player_silo'|'player_full',
+// entity_id=String(player.id)). Both the MLB silo cutout and the ESPN
+// full-body PNG are stored when both sources resolve.
+export const players = sqliteTable(
+  'players',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    userId: integer('user_id').notNull().default(1),
+    league: text('league').notNull(), // 'mlb', 'nfl', 'nba', 'wnba', 'ncaaf', 'ncaab', 'mls'
+    mlbStatsId: integer('mlb_stats_id'),
+    espnId: text('espn_id'),
+    fullName: text('full_name').notNull(),
+    firstName: text('first_name'),
+    lastName: text('last_name'),
+    primaryPosition: text('primary_position'),
+    primaryNumber: text('primary_number'), // jersey, kept as string ("00", "13", etc.)
+    birthDate: text('birth_date'), // YYYY-MM-DD
+    birthCity: text('birth_city'),
+    birthCountry: text('birth_country'),
+    bats: text('bats'), // L/R/B
+    throws: text('throws'), // L/R
+    primaryTeamId: integer('primary_team_id'), // league-specific team id
+    debutDate: text('debut_date'),
+    bioData: text('bio_data'), // JSON: any extra fields we want to keep around
+    createdAt: text('created_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+    updatedAt: text('updated_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => [
+    uniqueIndex('idx_players_league_mlb_stats_id').on(
+      table.league,
+      table.mlbStatsId
+    ),
+    uniqueIndex('idx_players_league_espn_id').on(table.league, table.espnId),
+    index('idx_players_team').on(table.primaryTeamId),
+    index('idx_players_last_name').on(table.lastName),
+  ]
+);
+
+// Per-game appearance: who played in a specific event, and what they did.
+// One row per (event, player). Roles aren't enforced — a player can have
+// both a batting line and a pitching line in the same row (interleague
+// pitcher hits, position player pitching, etc.). `decision` is set on
+// the pitcher of record. `notable` is a denormalized boolean we set
+// during sync for fast filtering ("show me the standout performances").
+export const attendedEventPlayers = sqliteTable(
+  'attended_event_players',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    userId: integer('user_id').notNull().default(1),
+    eventId: integer('event_id')
+      .notNull()
+      .references(() => attendedEvents.id, { onDelete: 'cascade' }),
+    playerId: integer('player_id')
+      .notNull()
+      .references(() => players.id),
+    teamId: integer('team_id'), // which team they played for in this game
+    isHome: integer('is_home').notNull().default(0), // 0/1
+    battingLine: text('batting_line'), // JSON: AB/R/H/RBI/BB/K/HR/avg/obp/slg/order
+    pitchingLine: text('pitching_line'), // JSON: IP/H/R/ER/BB/K/HR/pitches/strikes/era
+    fieldingLine: text('fielding_line'), // JSON: position-by-position innings
+    decision: text('decision', { enum: ['W', 'L', 'SV', 'HLD', 'BS'] }),
+    notable: integer('notable').notNull().default(0),
+    createdAt: text('created_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => [
+    uniqueIndex('idx_attended_event_players_unique').on(
+      table.eventId,
+      table.playerId
+    ),
+    index('idx_attended_event_players_event').on(table.eventId),
+    index('idx_attended_event_players_player').on(table.playerId),
+    index('idx_attended_event_players_decision').on(table.decision),
+    index('idx_attended_event_players_notable').on(table.notable),
+  ]
+);

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -573,4 +573,90 @@ adminAttending.openapi(reprocessRoute, async (c) => {
   }
 });
 
+// ─── POST /v1/admin/attending/enrich-boxscores ──────────────────────
+
+const EnrichBoxScoresBody = z
+  .object({
+    game_pks: z.array(z.number().int()).optional(),
+    skip_enriched: z.boolean().optional().default(true),
+    limit: z.number().int().min(1).max(500).optional().default(100),
+    dry_run: z.boolean().optional().default(false),
+  })
+  .openapi('AttendingEnrichBoxScoresBody');
+
+const EnrichBoxScoresResponse = z
+  .object({
+    status: z.literal('completed'),
+    scanned: z.number().int(),
+    enriched: z.number().int(),
+    players_inserted: z.number().int(),
+    players_updated: z.number().int(),
+    appearances_inserted: z.number().int(),
+    appearances_updated: z.number().int(),
+    failures: z.array(
+      z.object({ event_id: z.number().int(), reason: z.string() })
+    ),
+  })
+  .openapi('AttendingEnrichBoxScoresResponse');
+
+const enrichBoxScoresRoute = createRoute({
+  method: 'post',
+  path: '/admin/attending/enrich-boxscores',
+  operationId: 'adminAttendingEnrichBoxScores',
+  'x-hidden': true,
+  tags: ['Admin'],
+  summary: 'Backfill MLB box score data into attended events',
+  description:
+    'Pulls MLB Stats API box score + live feed for each attended MLB game, upserts every player who played, writes per-player appearance rows with batting/pitching lines, and merges game-level extras (attendance, weather, linescore, decisions) into attended_events.event_data. Idempotent — by default skips events already enriched. Use `skip_enriched: false` to force re-enrichment.',
+  request: {
+    body: {
+      content: { 'application/json': { schema: EnrichBoxScoresBody } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Enrichment completed',
+      content: { 'application/json': { schema: EnrichBoxScoresResponse } },
+    },
+    ...errorResponses(401, 500),
+  },
+});
+
+adminAttending.openapi(enrichBoxScoresRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  type Opts = {
+    game_pks?: number[];
+    skip_enriched?: boolean;
+    limit?: number;
+    dry_run?: boolean;
+  };
+  const body: Opts = await c.req.json<Opts>().catch(() => ({}) as Opts);
+
+  try {
+    const { enrichAttendedBoxScores } =
+      await import('../services/attending/enrich-boxscore.js');
+    const result = await enrichAttendedBoxScores(db, {
+      gamePks: body.game_pks,
+      skipEnriched: body.skip_enriched ?? true,
+      limit: body.limit ?? 100,
+      dryRun: body.dry_run ?? false,
+    });
+    return c.json({
+      status: 'completed' as const,
+      scanned: result.scanned,
+      enriched: result.enriched,
+      players_inserted: result.players_inserted,
+      players_updated: result.players_updated,
+      appearances_inserted: result.appearances_inserted,
+      appearances_updated: result.appearances_updated,
+      failures: result.failures,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`[ERROR] POST /admin/attending/enrich-boxscores: ${message}`);
+    return c.json({ error: message, status: 500 }, 500) as any;
+  }
+});
+
 export default adminAttending;

--- a/src/services/attending/enrich-boxscore.ts
+++ b/src/services/attending/enrich-boxscore.ts
@@ -1,0 +1,321 @@
+// Per-game enrichment: pull MLB Stats box score + live feed for each
+// attended MLB game, upsert players, write per-player appearance rows,
+// and merge game-level extras (attendance, weather, linescore,
+// decisions) into attendedEvents.eventData. Idempotent — safe to
+// re-run; existing rows update via ON CONFLICT.
+
+import { and, eq, sql } from 'drizzle-orm';
+import type { Database } from '../../db/client.js';
+import {
+  attendedEventPlayers,
+  attendedEvents,
+  players,
+} from '../../db/schema/attending.js';
+import {
+  fetchMlbBoxScore,
+  type MlbAppearance,
+  type MlbBoxScoreData,
+  type MlbPlayerBio,
+} from '../sports/mlb-boxscore.js';
+
+export interface BoxScoreEnrichOptions {
+  // External_id range filter — only enrich events with these gamePks.
+  gamePks?: number[];
+  // Skip events whose event_data already has the boxscore fields.
+  // Useful for incremental runs.
+  skipEnriched?: boolean;
+  limit?: number;
+  dryRun?: boolean;
+}
+
+export interface BoxScoreEnrichResult {
+  scanned: number;
+  enriched: number;
+  players_inserted: number;
+  players_updated: number;
+  appearances_inserted: number;
+  appearances_updated: number;
+  failures: Array<{ event_id: number; reason: string }>;
+}
+
+export async function enrichAttendedBoxScores(
+  db: Database,
+  opts: BoxScoreEnrichOptions = {}
+): Promise<BoxScoreEnrichResult> {
+  const { gamePks, skipEnriched = true, limit = 100, dryRun = false } = opts;
+  const result: BoxScoreEnrichResult = {
+    scanned: 0,
+    enriched: 0,
+    players_inserted: 0,
+    players_updated: 0,
+    appearances_inserted: 0,
+    appearances_updated: 0,
+    failures: [],
+  };
+
+  // Pull every attended MLB game with an MLB Stats external_id.
+  const events = await db
+    .select()
+    .from(attendedEvents)
+    .where(
+      and(
+        eq(attendedEvents.eventType, 'mlb_game'),
+        eq(attendedEvents.externalSource, 'mlb_stats_api')
+      )
+    )
+    .limit(limit);
+
+  for (const ev of events) {
+    if (!ev.externalId) continue;
+    const gamePk = parseInt(ev.externalId, 10);
+    if (Number.isNaN(gamePk)) continue;
+    if (gamePks && !gamePks.includes(gamePk)) continue;
+
+    const existingData: Record<string, unknown> = ev.eventData
+      ? (JSON.parse(ev.eventData) as Record<string, unknown>)
+      : {};
+    if (skipEnriched && existingData.attendance != null) {
+      // Already enriched — skip unless caller forces re-enrich.
+      continue;
+    }
+
+    result.scanned++;
+    let box: MlbBoxScoreData | null;
+    try {
+      box = await fetchMlbBoxScore(gamePk);
+    } catch (err) {
+      result.failures.push({
+        event_id: ev.id,
+        reason: `fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+    if (!box) {
+      result.failures.push({
+        event_id: ev.id,
+        reason: 'boxscore not found',
+      });
+      continue;
+    }
+
+    if (dryRun) {
+      result.enriched++;
+      continue;
+    }
+
+    try {
+      const counts = await persistBoxScore(db, ev.id, box, existingData);
+      result.enriched++;
+      result.players_inserted += counts.players_inserted;
+      result.players_updated += counts.players_updated;
+      result.appearances_inserted += counts.appearances_inserted;
+      result.appearances_updated += counts.appearances_updated;
+    } catch (err) {
+      result.failures.push({
+        event_id: ev.id,
+        reason: `persist failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  return result;
+}
+
+interface PersistCounts {
+  players_inserted: number;
+  players_updated: number;
+  appearances_inserted: number;
+  appearances_updated: number;
+}
+
+async function persistBoxScore(
+  db: Database,
+  eventId: number,
+  box: MlbBoxScoreData,
+  existingEventData: Record<string, unknown>
+): Promise<PersistCounts> {
+  const counts: PersistCounts = {
+    players_inserted: 0,
+    players_updated: 0,
+    appearances_inserted: 0,
+    appearances_updated: 0,
+  };
+
+  // Upsert each player and capture the players.id for the join row.
+  const playerIdByMlb = new Map<number, number>();
+  for (const a of box.appearances) {
+    const playerId = await upsertPlayer(db, a.player, a.team_id, counts);
+    playerIdByMlb.set(a.player.mlb_stats_id, playerId);
+  }
+
+  // Insert/update each appearance.
+  for (const a of box.appearances) {
+    const pid = playerIdByMlb.get(a.player.mlb_stats_id);
+    if (!pid) continue;
+    await upsertAppearance(db, eventId, pid, a, counts);
+  }
+
+  // Merge game-level extras into event_data and bump updated_at.
+  const merged: Record<string, unknown> = {
+    ...existingEventData,
+    attendance: box.attendance,
+    weather: box.weather,
+    duration_minutes: box.duration_minutes,
+    first_pitch: box.first_pitch,
+    linescore: box.linescore,
+    starting_pitchers: {
+      home_id: box.starting_pitcher_home_id,
+      away_id: box.starting_pitcher_away_id,
+    },
+    decisions: {
+      winner_id: box.winning_pitcher_id,
+      loser_id: box.losing_pitcher_id,
+      save_id: box.save_pitcher_id,
+    },
+    boxscore_enriched_at: new Date().toISOString(),
+  };
+  await db
+    .update(attendedEvents)
+    .set({
+      eventData: JSON.stringify(merged),
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(attendedEvents.id, eventId));
+
+  return counts;
+}
+
+async function upsertPlayer(
+  db: Database,
+  bio: MlbPlayerBio,
+  teamId: number,
+  counts: PersistCounts
+): Promise<number> {
+  const now = new Date().toISOString();
+
+  // Try to fetch existing row first to know whether this is insert or update.
+  const existing = await db
+    .select()
+    .from(players)
+    .where(
+      and(eq(players.league, 'mlb'), eq(players.mlbStatsId, bio.mlb_stats_id))
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    const ex = existing[0];
+    await db
+      .update(players)
+      .set({
+        fullName: bio.full_name,
+        firstName: bio.first_name ?? ex.firstName,
+        lastName: bio.last_name ?? ex.lastName,
+        primaryPosition: bio.primary_position ?? ex.primaryPosition,
+        primaryNumber: bio.primary_number ?? ex.primaryNumber,
+        birthDate: bio.birth_date ?? ex.birthDate,
+        birthCity: bio.birth_city ?? ex.birthCity,
+        birthCountry: bio.birth_country ?? ex.birthCountry,
+        bats: bio.bats ?? ex.bats,
+        throws: bio.throws ?? ex.throws,
+        debutDate: bio.debut_date ?? ex.debutDate,
+        primaryTeamId: teamId,
+        updatedAt: now,
+      })
+      .where(eq(players.id, ex.id));
+    counts.players_updated++;
+    return ex.id;
+  }
+
+  const [inserted] = await db
+    .insert(players)
+    .values({
+      userId: 1,
+      league: 'mlb',
+      mlbStatsId: bio.mlb_stats_id,
+      fullName: bio.full_name,
+      firstName: bio.first_name,
+      lastName: bio.last_name,
+      primaryPosition: bio.primary_position,
+      primaryNumber: bio.primary_number,
+      birthDate: bio.birth_date,
+      birthCity: bio.birth_city,
+      birthCountry: bio.birth_country,
+      bats: bio.bats,
+      throws: bio.throws,
+      primaryTeamId: teamId,
+      debutDate: bio.debut_date,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning({ id: players.id });
+  counts.players_inserted++;
+  return inserted.id;
+}
+
+async function upsertAppearance(
+  db: Database,
+  eventId: number,
+  playerId: number,
+  a: MlbAppearance,
+  counts: PersistCounts
+): Promise<void> {
+  const now = new Date().toISOString();
+  const battingJson = a.batting_line ? JSON.stringify(a.batting_line) : null;
+  const pitchingJson = a.pitching_line ? JSON.stringify(a.pitching_line) : null;
+
+  const existing = await db
+    .select()
+    .from(attendedEventPlayers)
+    .where(
+      and(
+        eq(attendedEventPlayers.eventId, eventId),
+        eq(attendedEventPlayers.playerId, playerId)
+      )
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db
+      .update(attendedEventPlayers)
+      .set({
+        teamId: a.team_id,
+        isHome: a.is_home ? 1 : 0,
+        battingLine: battingJson,
+        pitchingLine: pitchingJson,
+        decision: a.decision,
+        notable: a.notable ? 1 : 0,
+      })
+      .where(eq(attendedEventPlayers.id, existing[0].id));
+    counts.appearances_updated++;
+    return;
+  }
+
+  await db.insert(attendedEventPlayers).values({
+    userId: 1,
+    eventId,
+    playerId,
+    teamId: a.team_id,
+    isHome: a.is_home ? 1 : 0,
+    battingLine: battingJson,
+    pitchingLine: pitchingJson,
+    decision: a.decision,
+    notable: a.notable ? 1 : 0,
+    createdAt: now,
+  });
+  counts.appearances_inserted++;
+}
+
+// Convenience: count attended MLB games that have NOT been enriched yet.
+export async function countUnenrichedMlbGames(db: Database): Promise<number> {
+  const rows = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(attendedEvents)
+    .where(
+      and(
+        eq(attendedEvents.eventType, 'mlb_game'),
+        eq(attendedEvents.externalSource, 'mlb_stats_api'),
+        sql`(${attendedEvents.eventData} IS NULL OR json_extract(${attendedEvents.eventData}, '$.boxscore_enriched_at') IS NULL)`
+      )
+    );
+  return rows[0]?.count ?? 0;
+}

--- a/src/services/sports/mlb-boxscore.test.ts
+++ b/src/services/sports/mlb-boxscore.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchMlbBoxScore } from './mlb-boxscore.js';
+
+// Minimal fixtures patterned on real responses from
+// https://statsapi.mlb.com/api/v1/game/745223/boxscore and
+// https://statsapi.mlb.com/api/v1.1/game/745223/feed/live (Mariners
+// vs Tigers, 2024-08-07).
+const BOXSCORE_FIXTURE = {
+  teams: {
+    home: {
+      team: { id: 136, name: 'Seattle Mariners' },
+      pitchers: [669923, 669402], // Kirby starts
+      battingOrder: [
+        645302, 663656, 641933, 596142, 668939, 671277, 673357, 668800, 666144,
+      ],
+      players: {
+        ID669923: {
+          person: {
+            id: 669923,
+            fullName: 'George Kirby',
+            firstName: 'George',
+            lastName: 'Kirby',
+            primaryNumber: '68',
+            mlbDebutDate: '2022-05-08',
+            batSide: { code: 'L' },
+            pitchHand: { code: 'R' },
+          },
+          jerseyNumber: '68',
+          position: { abbreviation: 'P' },
+          stats: {
+            pitching: {
+              gamesPlayed: 1,
+              inningsPitched: '7.0',
+              hits: 4,
+              runs: 1,
+              earnedRuns: 1,
+              baseOnBalls: 1,
+              strikeOuts: 6,
+              homeRuns: 1,
+              numberOfPitches: 97,
+              strikes: 65,
+              battersFaced: 23,
+              era: '3.45',
+              summary: '7.0 IP, 4 H, 1 R, 1 ER, 1 BB, 6 K',
+            },
+          },
+        },
+        ID645302: {
+          person: {
+            id: 645302,
+            fullName: 'Victor Robles',
+            firstName: 'Victor',
+            lastName: 'Robles',
+            primaryNumber: '10',
+            batSide: { code: 'R' },
+            pitchHand: { code: 'R' },
+          },
+          jerseyNumber: '10',
+          position: { abbreviation: 'CF' },
+          battingOrder: '100',
+          stats: {
+            batting: {
+              gamesPlayed: 1,
+              atBats: 4,
+              runs: 0,
+              hits: 0,
+              rbi: 0,
+              baseOnBalls: 0,
+              strikeOuts: 1,
+              homeRuns: 0,
+              doubles: 0,
+              triples: 0,
+              stolenBases: 0,
+              hitByPitch: 0,
+              plateAppearances: 4,
+              totalBases: 0,
+              leftOnBase: 0,
+              summary: '0-4 | K',
+            },
+          },
+        },
+        ID596142: {
+          person: {
+            id: 596142,
+            fullName: 'Cal Raleigh',
+            firstName: 'Cal',
+            lastName: 'Raleigh',
+            primaryNumber: '29',
+            batSide: { code: 'B' },
+            pitchHand: { code: 'R' },
+          },
+          jerseyNumber: '29',
+          position: { abbreviation: 'C' },
+          battingOrder: '400',
+          stats: {
+            batting: {
+              gamesPlayed: 1,
+              atBats: 4,
+              runs: 1,
+              hits: 2,
+              rbi: 1,
+              baseOnBalls: 0,
+              strikeOuts: 1,
+              homeRuns: 1,
+              doubles: 0,
+              triples: 0,
+              stolenBases: 0,
+              hitByPitch: 0,
+              plateAppearances: 4,
+              totalBases: 5,
+              leftOnBase: 1,
+              summary: '2-4, HR, RBI',
+            },
+          },
+        },
+      },
+    },
+    away: {
+      team: { id: 116, name: 'Detroit Tigers' },
+      pitchers: [669373], // Skubal
+      players: {
+        ID669373: {
+          person: {
+            id: 669373,
+            fullName: 'Tarik Skubal',
+            firstName: 'Tarik',
+            lastName: 'Skubal',
+            primaryNumber: '29',
+            batSide: { code: 'L' },
+            pitchHand: { code: 'L' },
+          },
+          jerseyNumber: '29',
+          position: { abbreviation: 'P' },
+          stats: {
+            pitching: {
+              gamesPlayed: 1,
+              inningsPitched: '8.0',
+              hits: 3,
+              runs: 1,
+              earnedRuns: 1,
+              baseOnBalls: 1,
+              strikeOuts: 12,
+              homeRuns: 1,
+              numberOfPitches: 102,
+              strikes: 70,
+              battersFaced: 26,
+              era: '2.45',
+              summary: '8.0 IP, 3 H, 1 R, 1 ER, 12 K (W)',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const FEED_FIXTURE = {
+  gamePk: 745223,
+  gameData: {
+    gameInfo: {
+      attendance: 26033,
+      firstPitch: '2024-08-08T01:42:00.000Z',
+      gameDurationMinutes: 153,
+    },
+    weather: { condition: 'Clear', temp: '73', wind: '2 mph, In From LF' },
+    venue: { name: 'T-Mobile Park' },
+  },
+  liveData: {
+    linescore: {
+      innings: [
+        {
+          num: 1,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 2,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 3,
+          home: { runs: 0, hits: 1, errors: 0 },
+          away: { runs: 1, hits: 1, errors: 0 },
+        },
+        {
+          num: 4,
+          home: { runs: 1, hits: 1, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 5,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 6,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 7,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 8,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+        {
+          num: 9,
+          home: { runs: 0, hits: 0, errors: 0 },
+          away: { runs: 0, hits: 0, errors: 0 },
+        },
+      ],
+    },
+    decisions: {
+      winner: { id: 669373, fullName: 'Tarik Skubal' },
+      loser: { id: 669923, fullName: 'George Kirby' },
+    },
+  },
+};
+
+describe('fetchMlbBoxScore', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes('/boxscore')) {
+        return new Response(JSON.stringify(BOXSCORE_FIXTURE), { status: 200 });
+      }
+      if (u.includes('/feed/live')) {
+        return new Response(JSON.stringify(FEED_FIXTURE), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns null when boxscore is 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not found', { status: 404 })
+    );
+    expect(await fetchMlbBoxScore(123456)).toBeNull();
+  });
+
+  it('parses game-level fields from feed/live', async () => {
+    const data = await fetchMlbBoxScore(745223);
+    expect(data).not.toBeNull();
+    expect(data!.attendance).toBe(26033);
+    expect(data!.weather).toEqual({
+      condition: 'Clear',
+      temp: '73',
+      wind: '2 mph, In From LF',
+    });
+    expect(data!.duration_minutes).toBe(153);
+    expect(data!.venue_name).toBe('T-Mobile Park');
+    expect(data!.linescore).toHaveLength(9);
+    expect(data!.winning_pitcher_id).toBe(669373);
+    expect(data!.losing_pitcher_id).toBe(669923);
+    expect(data!.save_pitcher_id).toBeNull();
+  });
+
+  it('extracts starting pitchers from each side', async () => {
+    const data = await fetchMlbBoxScore(745223);
+    expect(data!.starting_pitcher_home_id).toBe(669923); // Kirby
+    expect(data!.starting_pitcher_away_id).toBe(669373); // Skubal
+  });
+
+  it('parses pitching lines + decision flags', async () => {
+    const data = await fetchMlbBoxScore(745223);
+    const skubal = data!.appearances.find(
+      (a) => a.player.mlb_stats_id === 669373
+    );
+    expect(skubal).toBeDefined();
+    expect(skubal!.decision).toBe('W');
+    expect(skubal!.is_starter_pitcher).toBe(true);
+    expect(skubal!.notable).toBe(true);
+    expect(skubal!.pitching_line).toMatchObject({
+      ip: '8.0',
+      k: 12,
+      er: 1,
+      pitches: 102,
+      strikes: 70,
+    });
+  });
+
+  it('parses batting lines + flags multi-hit / HR as notable', async () => {
+    const data = await fetchMlbBoxScore(745223);
+    const raleigh = data!.appearances.find(
+      (a) => a.player.mlb_stats_id === 596142
+    );
+    expect(raleigh).toBeDefined();
+    expect(raleigh!.batting_line).toMatchObject({
+      ab: 4,
+      h: 2,
+      hr: 1,
+      rbi: 1,
+    });
+    expect(raleigh!.notable).toBe(true); // 2 hits + HR
+    expect(raleigh!.batting_order).toBe(400);
+  });
+
+  it('does NOT flag a 0-for-4 single-K as notable', async () => {
+    const data = await fetchMlbBoxScore(745223);
+    const robles = data!.appearances.find(
+      (a) => a.player.mlb_stats_id === 645302
+    );
+    expect(robles).toBeDefined();
+    expect(robles!.notable).toBe(false);
+    expect(robles!.batting_line).toMatchObject({ ab: 4, h: 0, k: 1 });
+  });
+
+  it('preserves bio fields for players', async () => {
+    const data = await fetchMlbBoxScore(745223);
+    const kirby = data!.appearances.find(
+      (a) => a.player.mlb_stats_id === 669923
+    );
+    expect(kirby!.player).toMatchObject({
+      mlb_stats_id: 669923,
+      full_name: 'George Kirby',
+      first_name: 'George',
+      last_name: 'Kirby',
+      primary_position: 'P',
+      primary_number: '68',
+      throws: 'R',
+      debut_date: '2022-05-08',
+    });
+  });
+});

--- a/src/services/sports/mlb-boxscore.ts
+++ b/src/services/sports/mlb-boxscore.ts
@@ -1,0 +1,356 @@
+// MLB Stats API box score + live feed client. Pulls per-player stat
+// lines, decisions, attendance, weather, and linescore for an attended
+// game. Two endpoint versions:
+//   v1   /game/{gamePk}/boxscore  — players + per-player stats
+//   v1.1 /game/{gamePk}/feed/live — linescore, weather, attendance,
+//                                    decisions, duration
+// Both unauthenticated. Combine into one normalized payload.
+
+const V1 = 'https://statsapi.mlb.com/api/v1';
+const V1_1 = 'https://statsapi.mlb.com/api/v1.1';
+
+export interface MlbPlayerBio {
+  mlb_stats_id: number;
+  full_name: string;
+  first_name: string | null;
+  last_name: string | null;
+  primary_position: string | null;
+  primary_number: string | null;
+  birth_date: string | null;
+  birth_city: string | null;
+  birth_country: string | null;
+  bats: string | null;
+  throws: string | null;
+  debut_date: string | null;
+}
+
+export interface MlbBattingLine {
+  ab: number;
+  r: number;
+  h: number;
+  rbi: number;
+  bb: number;
+  k: number;
+  hr: number;
+  doubles: number;
+  triples: number;
+  sb: number;
+  hbp: number;
+  pa: number;
+  total_bases: number;
+  left_on_base: number;
+  summary: string | null;
+}
+
+export interface MlbPitchingLine {
+  ip: string; // "6.2" — innings pitched is fractional, kept as string
+  h: number;
+  r: number;
+  er: number;
+  bb: number;
+  k: number;
+  hr: number;
+  pitches: number | null;
+  strikes: number | null;
+  era: string | null;
+  batters_faced: number | null;
+  summary: string | null;
+}
+
+export interface MlbAppearance {
+  player: MlbPlayerBio;
+  team_id: number;
+  is_home: boolean;
+  batting_line: MlbBattingLine | null;
+  pitching_line: MlbPitchingLine | null;
+  decision: 'W' | 'L' | 'SV' | 'HLD' | 'BS' | null;
+  notable: boolean; // HR, multi-hit, decision, or starting pitcher
+  is_starter_pitcher: boolean;
+  batting_order: number | null; // 100s = lineup, 200s = sub
+}
+
+export interface MlbBoxScoreData {
+  game_pk: number;
+  attendance: number | null;
+  weather: { condition: string; temp: string; wind: string } | null;
+  venue_name: string | null;
+  first_pitch: string | null; // ISO
+  duration_minutes: number | null;
+  linescore: Array<{
+    inning: number;
+    home_runs: number | null;
+    away_runs: number | null;
+    home_hits: number | null;
+    away_hits: number | null;
+    home_errors: number | null;
+    away_errors: number | null;
+  }>;
+  starting_pitcher_home_id: number | null;
+  starting_pitcher_away_id: number | null;
+  winning_pitcher_id: number | null;
+  losing_pitcher_id: number | null;
+  save_pitcher_id: number | null;
+  appearances: MlbAppearance[];
+}
+
+interface RawBoxScore {
+  teams: {
+    home: RawTeamSide;
+    away: RawTeamSide;
+  };
+  officials?: Array<{ official: { id: number; fullName: string } }>;
+}
+
+interface RawTeamSide {
+  team: { id: number; name: string };
+  players: Record<string, RawPlayer>; // keys like "ID660271"
+  pitchers?: number[]; // ordered list
+  battingOrder?: number[]; // 9 ids in lineup order
+}
+
+interface RawPlayer {
+  person: {
+    id: number;
+    fullName: string;
+    firstName?: string;
+    lastName?: string;
+    birthDate?: string;
+    birthCity?: string;
+    birthCountry?: string;
+    primaryNumber?: string;
+    mlbDebutDate?: string;
+    batSide?: { code?: string };
+    pitchHand?: { code?: string };
+  };
+  jerseyNumber?: string;
+  position?: { abbreviation?: string };
+  battingOrder?: string; // "100" / "200"
+  stats?: {
+    batting?: Record<string, number | string>;
+    pitching?: Record<string, number | string>;
+    fielding?: Record<string, number | string>;
+  };
+  gameStatus?: { isCurrentBatter?: boolean; isOnBench?: boolean };
+}
+
+interface RawLiveFeed {
+  gamePk: number;
+  gameData: {
+    gameInfo?: {
+      attendance?: number;
+      firstPitch?: string;
+      gameDurationMinutes?: number;
+    };
+    weather?: { condition?: string; temp?: string; wind?: string };
+    venue?: { name?: string };
+  };
+  liveData: {
+    linescore?: {
+      innings?: Array<{
+        num: number;
+        home?: { runs?: number; hits?: number; errors?: number };
+        away?: { runs?: number; hits?: number; errors?: number };
+      }>;
+    };
+    decisions?: {
+      winner?: { id: number };
+      loser?: { id: number };
+      save?: { id: number };
+    };
+  };
+}
+
+/**
+ * Fetch + normalize a full MLB game's box score and live feed.
+ * Returns null if the game is not found (404 from either endpoint).
+ */
+export async function fetchMlbBoxScore(
+  gamePk: number
+): Promise<MlbBoxScoreData | null> {
+  const [boxRes, liveRes] = await Promise.all([
+    fetch(`${V1}/game/${gamePk}/boxscore`),
+    fetch(`${V1_1}/game/${gamePk}/feed/live`),
+  ]);
+  if (!boxRes.ok || !liveRes.ok) return null;
+  const box = (await boxRes.json()) as RawBoxScore;
+  const live = (await liveRes.json()) as RawLiveFeed;
+
+  const appearances: MlbAppearance[] = [];
+  for (const side of ['home', 'away'] as const) {
+    const teamSide = box.teams[side];
+    if (!teamSide) continue;
+    const isHome = side === 'home';
+    const startingPitcherId = teamSide.pitchers?.[0] ?? null;
+    for (const playerKey of Object.keys(teamSide.players)) {
+      const raw = teamSide.players[playerKey];
+      const a = toAppearance(
+        raw,
+        teamSide.team.id,
+        isHome,
+        startingPitcherId,
+        live.liveData.decisions ?? {}
+      );
+      if (a) appearances.push(a);
+    }
+  }
+
+  const decisions = live.liveData.decisions ?? {};
+  const innings = live.liveData.linescore?.innings ?? [];
+  const linescore = innings.map((inn) => ({
+    inning: inn.num,
+    home_runs: inn.home?.runs ?? null,
+    away_runs: inn.away?.runs ?? null,
+    home_hits: inn.home?.hits ?? null,
+    away_hits: inn.away?.hits ?? null,
+    home_errors: inn.home?.errors ?? null,
+    away_errors: inn.away?.errors ?? null,
+  }));
+
+  const homePitchers = box.teams.home?.pitchers ?? [];
+  const awayPitchers = box.teams.away?.pitchers ?? [];
+  const gi = live.gameData.gameInfo ?? {};
+  const w = live.gameData.weather ?? {};
+
+  return {
+    game_pk: live.gamePk ?? gamePk,
+    attendance: gi.attendance ?? null,
+    weather:
+      w.condition || w.temp || w.wind
+        ? {
+            condition: w.condition ?? '',
+            temp: w.temp ?? '',
+            wind: w.wind ?? '',
+          }
+        : null,
+    venue_name: live.gameData.venue?.name ?? null,
+    first_pitch: gi.firstPitch ?? null,
+    duration_minutes: gi.gameDurationMinutes ?? null,
+    linescore,
+    starting_pitcher_home_id: homePitchers[0] ?? null,
+    starting_pitcher_away_id: awayPitchers[0] ?? null,
+    winning_pitcher_id: decisions.winner?.id ?? null,
+    losing_pitcher_id: decisions.loser?.id ?? null,
+    save_pitcher_id: decisions.save?.id ?? null,
+    appearances,
+  };
+}
+
+function toAppearance(
+  raw: RawPlayer,
+  teamId: number,
+  isHome: boolean,
+  startingPitcherId: number | null,
+  decisions: {
+    winner?: { id: number };
+    loser?: { id: number };
+    save?: { id: number };
+  }
+): MlbAppearance | null {
+  const id = raw.person.id;
+  if (!id) return null;
+  const isStarter = startingPitcherId === id;
+  const decision: MlbAppearance['decision'] =
+    decisions.winner?.id === id
+      ? 'W'
+      : decisions.loser?.id === id
+        ? 'L'
+        : decisions.save?.id === id
+          ? 'SV'
+          : null;
+
+  const battingLine = parseBattingLine(raw.stats?.batting);
+  const pitchingLine = parsePitchingLine(raw.stats?.pitching);
+
+  // "Notable" heuristic: had a hit-with-pop, a multi-hit game, was a
+  // pitcher of record, or started the game on the mound. Set on sync
+  // so consumer queries can filter for highlights cheaply.
+  const notable =
+    decision !== null ||
+    isStarter ||
+    (battingLine != null && (battingLine.h >= 2 || battingLine.hr >= 1));
+
+  return {
+    player: toBio(raw),
+    team_id: teamId,
+    is_home: isHome,
+    batting_line: battingLine,
+    pitching_line: pitchingLine,
+    decision,
+    notable,
+    is_starter_pitcher: isStarter,
+    batting_order:
+      raw.battingOrder != null && raw.battingOrder !== ''
+        ? parseInt(raw.battingOrder, 10)
+        : null,
+  };
+}
+
+function toBio(raw: RawPlayer): MlbPlayerBio {
+  const p = raw.person;
+  return {
+    mlb_stats_id: p.id,
+    full_name: p.fullName,
+    first_name: p.firstName ?? null,
+    last_name: p.lastName ?? null,
+    primary_position: raw.position?.abbreviation ?? null,
+    primary_number: raw.jerseyNumber ?? p.primaryNumber ?? null,
+    birth_date: p.birthDate ?? null,
+    birth_city: p.birthCity ?? null,
+    birth_country: p.birthCountry ?? null,
+    bats: p.batSide?.code ?? null,
+    throws: p.pitchHand?.code ?? null,
+    debut_date: p.mlbDebutDate ?? null,
+  };
+}
+
+function num(v: number | string | undefined): number {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') {
+    const n = parseInt(v, 10);
+    return Number.isNaN(n) ? 0 : n;
+  }
+  return 0;
+}
+
+function parseBattingLine(
+  raw: Record<string, number | string> | undefined
+): MlbBattingLine | null {
+  if (!raw || raw.gamesPlayed == null) return null;
+  return {
+    ab: num(raw.atBats),
+    r: num(raw.runs),
+    h: num(raw.hits),
+    rbi: num(raw.rbi),
+    bb: num(raw.baseOnBalls),
+    k: num(raw.strikeOuts),
+    hr: num(raw.homeRuns),
+    doubles: num(raw.doubles),
+    triples: num(raw.triples),
+    sb: num(raw.stolenBases),
+    hbp: num(raw.hitByPitch),
+    pa: num(raw.plateAppearances),
+    total_bases: num(raw.totalBases),
+    left_on_base: num(raw.leftOnBase),
+    summary: typeof raw.summary === 'string' ? raw.summary : null,
+  };
+}
+
+function parsePitchingLine(
+  raw: Record<string, number | string> | undefined
+): MlbPitchingLine | null {
+  if (!raw || raw.gamesPlayed == null) return null;
+  return {
+    ip: typeof raw.inningsPitched === 'string' ? raw.inningsPitched : '0.0',
+    h: num(raw.hits),
+    r: num(raw.runs),
+    er: num(raw.earnedRuns),
+    bb: num(raw.baseOnBalls),
+    k: num(raw.strikeOuts),
+    hr: num(raw.homeRuns),
+    pitches: raw.numberOfPitches != null ? num(raw.numberOfPitches) : null,
+    strikes: raw.strikes != null ? num(raw.strikes) : null,
+    era: typeof raw.era === 'string' ? raw.era : null,
+    batters_faced: raw.battersFaced != null ? num(raw.battersFaced) : null,
+    summary: typeof raw.summary === 'string' ? raw.summary : null,
+  };
+}


### PR DESCRIPTION
## Summary

PR A of the player-stats + photos work. Adds the **data layer** for surfacing per-game player stats and photos on attended MLB games. No UI yet, no photos yet — those come in PR B.

### What lands

- **Schema (migration 0034):**
  - \`players\` — full bio (mlb_stats_id, espn_id, name, position, bats/throws, debut, birthplace, jersey). League discriminator (mlb/nfl/nba/etc). Photos live separately in the existing \`images\` table.
  - \`attended_event_players\` join — one row per (event, player) appearance with batting_line / pitching_line / fielding_line as JSON, decision (W/L/SV/HLD/BS), notable flag denormalized for fast filtering.

- **Sync service** (\`enrich-boxscore.ts\`):
  - Pulls \`/api/v1/game/{gamePk}/boxscore\` and \`/api/v1.1/game/{gamePk}/feed/live\` in parallel for each attended MLB game.
  - Upserts every player who appeared (home + away).
  - Writes one appearance row per (event, player) with full stat lines.
  - Merges game-level extras into \`event_data\`: attendance, weather, duration, linescore (inning-by-inning), starting pitchers, W/L/S decisions, \`boxscore_enriched_at\`.
  - Idempotent: existing players/appearances UPDATE on conflict; events with \`boxscore_enriched_at\` are skipped unless \`skip_enriched: false\`.

- **Admin endpoint:** \`POST /v1/admin/attending/enrich-boxscores\` runs the backfill. Optional \`game_pks\` filter for targeted re-runs. Returns counts.

### Capture-broadly bias

Per-player batting/pitching/fielding lines stored as JSON so future UIs (year-in-review, hero stats, "best games I saw") can render any cut without re-fetching.

### Test plan

- [x] All 864 vitest cases pass (7 new boxscore parser tests cover 404 fallthrough, game-level field extraction, starting-pitcher detection, decision flags, notable heuristic, bio mapping)
- [x] Migration applied locally and to remote D1
- [x] Type check, ESLint, OpenAPI spec all green
- [ ] Post-merge: \`POST /v1/admin/attending/enrich-boxscores\` to backfill the 45 attended Mariners games
- [ ] Verify per-player rows + game-level extras

### Next (PR B)

- Image pipeline for player photos (MLB silo + ESPN full)
- API surface: \`/v1/attending/events/{id}\` gains \`players\` array; new \`/v1/attending/players\` browse + detail routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)