### PR TITLE
feat(attending): player photos + ESPN cross-ref + API surface

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -870,6 +870,154 @@
           }
         }
       },
+      "AttendingEnrichPlayerPhotosResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "silo_inserted": {
+            "type": "integer"
+          },
+          "silo_skipped": {
+            "type": "integer"
+          },
+          "silo_failed": {
+            "type": "integer"
+          },
+          "full_inserted": {
+            "type": "integer"
+          },
+          "full_skipped": {
+            "type": "integer"
+          },
+          "full_failed": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "player_id": {
+                  "type": "integer"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "player_id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "silo_inserted",
+          "silo_skipped",
+          "silo_failed",
+          "full_inserted",
+          "full_skipped",
+          "full_failed",
+          "failures"
+        ]
+      },
+      "AttendingEnrichPlayerPhotosBody": {
+        "type": "object",
+        "properties": {
+          "player_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "skip_existing": {
+            "type": "boolean",
+            "default": true
+          },
+          "silo_only": {
+            "type": "boolean",
+            "default": false
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000,
+            "default": 1000
+          }
+        }
+      },
+      "AttendingEnrichEspnIdsResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned_events": {
+            "type": "integer"
+          },
+          "matched_events": {
+            "type": "integer"
+          },
+          "resolved_player_ids": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "event_id": {
+                  "type": "integer"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event_id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned_events",
+          "matched_events",
+          "resolved_player_ids",
+          "failures"
+        ]
+      },
+      "AttendingEnrichEspnIdsBody": {
+        "type": "object",
+        "properties": {
+          "event_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100
+          }
+        }
+      },
       "SyncCompletedResponse": {
         "type": "object",
         "properties": {
@@ -18155,6 +18303,244 @@
                           "purchased_at"
                         ]
                       }
+                    },
+                    "players": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "player": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number",
+                                "example": 42
+                              },
+                              "league": {
+                                "type": "string",
+                                "example": "mlb"
+                              },
+                              "mlb_stats_id": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ],
+                                "example": 663728
+                              },
+                              "espn_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "41292"
+                              },
+                              "full_name": {
+                                "type": "string",
+                                "example": "Cal Raleigh"
+                              },
+                              "primary_position": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "C"
+                              },
+                              "primary_number": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "29"
+                              },
+                              "birth_date": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "1996-11-26"
+                              },
+                              "birth_country": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "USA"
+                              },
+                              "bats": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "B"
+                              },
+                              "throws": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "R"
+                              },
+                              "primary_team_id": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ],
+                                "example": 136
+                              },
+                              "debut_date": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "2021-07-11"
+                              },
+                              "photo_silo": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "cdn_url": {
+                                    "type": "string",
+                                    "example": "https://cdn.rewind.rest/.../players/silo/123"
+                                  },
+                                  "thumbhash": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "dominant_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#1a3a6c"
+                                  },
+                                  "accent_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#c4ced4"
+                                  }
+                                },
+                                "required": [
+                                  "cdn_url",
+                                  "thumbhash",
+                                  "dominant_color",
+                                  "accent_color"
+                                ]
+                              },
+                              "photo_full": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "cdn_url": {
+                                    "type": "string",
+                                    "example": "https://cdn.rewind.rest/.../players/silo/123"
+                                  },
+                                  "thumbhash": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "dominant_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#1a3a6c"
+                                  },
+                                  "accent_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#c4ced4"
+                                  }
+                                },
+                                "required": [
+                                  "cdn_url",
+                                  "thumbhash",
+                                  "dominant_color",
+                                  "accent_color"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "league",
+                              "mlb_stats_id",
+                              "espn_id",
+                              "full_name",
+                              "primary_position",
+                              "primary_number",
+                              "birth_date",
+                              "birth_country",
+                              "bats",
+                              "throws",
+                              "primary_team_id",
+                              "debut_date",
+                              "photo_silo",
+                              "photo_full"
+                            ]
+                          },
+                          "team_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "is_home": {
+                            "type": "boolean"
+                          },
+                          "batting_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "pitching_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "fielding_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "decision": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "W"
+                          },
+                          "notable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "player",
+                          "team_id",
+                          "is_home",
+                          "batting_line",
+                          "pitching_line",
+                          "fielding_line",
+                          "decision",
+                          "notable"
+                        ]
+                      }
                     }
                   },
                   "required": [
@@ -18172,7 +18558,8 @@
                     "notes",
                     "attended",
                     "venue",
-                    "tickets"
+                    "tickets",
+                    "players"
                   ]
                 }
               }
@@ -18729,6 +19116,567 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/attending/players": {
+      "get": {
+        "operationId": "listAttendedPlayers",
+        "tags": [
+          "Attending"
+        ],
+        "summary": "List players you have watched play",
+        "description": "Returns players who appeared in any attended sports event. Filterable by league and team_id. Includes both photo variants when available.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "mlb"
+            },
+            "required": false,
+            "name": "league",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "example": 136
+            },
+            "required": false,
+            "name": "team_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Players",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number",
+                            "example": 42
+                          },
+                          "league": {
+                            "type": "string",
+                            "example": "mlb"
+                          },
+                          "mlb_stats_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ],
+                            "example": 663728
+                          },
+                          "espn_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "41292"
+                          },
+                          "full_name": {
+                            "type": "string",
+                            "example": "Cal Raleigh"
+                          },
+                          "primary_position": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "C"
+                          },
+                          "primary_number": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "29"
+                          },
+                          "birth_date": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "1996-11-26"
+                          },
+                          "birth_country": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "USA"
+                          },
+                          "bats": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "B"
+                          },
+                          "throws": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "R"
+                          },
+                          "primary_team_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ],
+                            "example": 136
+                          },
+                          "debut_date": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "2021-07-11"
+                          },
+                          "photo_silo": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "cdn_url": {
+                                "type": "string",
+                                "example": "https://cdn.rewind.rest/.../players/silo/123"
+                              },
+                              "thumbhash": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "dominant_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#1a3a6c"
+                              },
+                              "accent_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#c4ced4"
+                              }
+                            },
+                            "required": [
+                              "cdn_url",
+                              "thumbhash",
+                              "dominant_color",
+                              "accent_color"
+                            ]
+                          },
+                          "photo_full": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "cdn_url": {
+                                "type": "string",
+                                "example": "https://cdn.rewind.rest/.../players/silo/123"
+                              },
+                              "thumbhash": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "dominant_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#1a3a6c"
+                              },
+                              "accent_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#c4ced4"
+                              }
+                            },
+                            "required": [
+                              "cdn_url",
+                              "thumbhash",
+                              "dominant_color",
+                              "accent_color"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "league",
+                          "mlb_stats_id",
+                          "espn_id",
+                          "full_name",
+                          "primary_position",
+                          "primary_number",
+                          "birth_date",
+                          "birth_country",
+                          "bats",
+                          "throws",
+                          "primary_team_id",
+                          "debut_date",
+                          "photo_silo",
+                          "photo_full"
+                        ]
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "pagination"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/attending/players/{id}": {
+      "get": {
+        "operationId": "getAttendedPlayer",
+        "tags": [
+          "Attending"
+        ],
+        "summary": "Get a player you have watched play",
+        "description": "Returns the player bio with both photo variants when available, plus a list of every attended event in which they appeared along with that game's stat lines.",
+        "parameters": [
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                      "example": 42
+                    },
+                    "league": {
+                      "type": "string",
+                      "example": "mlb"
+                    },
+                    "mlb_stats_id": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "example": 663728
+                    },
+                    "espn_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "41292"
+                    },
+                    "full_name": {
+                      "type": "string",
+                      "example": "Cal Raleigh"
+                    },
+                    "primary_position": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "C"
+                    },
+                    "primary_number": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "29"
+                    },
+                    "birth_date": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "1996-11-26"
+                    },
+                    "birth_country": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "USA"
+                    },
+                    "bats": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "B"
+                    },
+                    "throws": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "R"
+                    },
+                    "primary_team_id": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "example": 136
+                    },
+                    "debut_date": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "2021-07-11"
+                    },
+                    "photo_silo": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "cdn_url": {
+                          "type": "string",
+                          "example": "https://cdn.rewind.rest/.../players/silo/123"
+                        },
+                        "thumbhash": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "dominant_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#1a3a6c"
+                        },
+                        "accent_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#c4ced4"
+                        }
+                      },
+                      "required": [
+                        "cdn_url",
+                        "thumbhash",
+                        "dominant_color",
+                        "accent_color"
+                      ]
+                    },
+                    "photo_full": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "cdn_url": {
+                          "type": "string",
+                          "example": "https://cdn.rewind.rest/.../players/silo/123"
+                        },
+                        "thumbhash": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "dominant_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#1a3a6c"
+                        },
+                        "accent_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#c4ced4"
+                        }
+                      },
+                      "required": [
+                        "cdn_url",
+                        "thumbhash",
+                        "dominant_color",
+                        "accent_color"
+                      ]
+                    },
+                    "appearances": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "event_id": {
+                            "type": "number"
+                          },
+                          "event_date": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "team_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "is_home": {
+                            "type": "boolean"
+                          },
+                          "batting_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "pitching_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "decision": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "notable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "event_id",
+                          "event_date",
+                          "title",
+                          "team_id",
+                          "is_home",
+                          "batting_line",
+                          "pitching_line",
+                          "decision",
+                          "notable"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "league",
+                    "mlb_stats_id",
+                    "espn_id",
+                    "full_name",
+                    "primary_position",
+                    "primary_number",
+                    "birth_date",
+                    "birth_country",
+                    "bats",
+                    "throws",
+                    "primary_team_id",
+                    "debut_date",
+                    "photo_silo",
+                    "photo_full",
+                    "appearances"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -20695,6 +21643,112 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingEnrichBoxScoresResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-player-photos": {
+      "post": {
+        "operationId": "adminAttendingEnrichPlayerPhotos",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Backfill player photos through the image pipeline",
+        "description": "Fetches the MLB silo cutout for every player and the ESPN full-body PNG when an espn_id is known. Stores both via the existing image pipeline (R2 + thumbhash + dominant_color) keyed on (domain='attending', entity_type='player_silo'|'player_full'). Idempotent.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichPlayerPhotosBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Photo backfill completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichPlayerPhotosResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-espn-ids": {
+      "post": {
+        "operationId": "adminAttendingEnrichEspnIds",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Resolve ESPN player IDs via game summaries",
+        "description": "For each attended MLB game, hits ESPN’s schedule + summary endpoints, walks the box score, and matches each ESPN athlete to an MLB player by last_name + jersey to populate players.espn_id. Run before enrich-player-photos to unlock the ESPN full-body photo variant.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichEspnIdsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ESPN ID cross-reference completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichEspnIdsResponse"
                 }
               }
             }

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -870,6 +870,154 @@
           }
         }
       },
+      "AttendingEnrichPlayerPhotosResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "silo_inserted": {
+            "type": "integer"
+          },
+          "silo_skipped": {
+            "type": "integer"
+          },
+          "silo_failed": {
+            "type": "integer"
+          },
+          "full_inserted": {
+            "type": "integer"
+          },
+          "full_skipped": {
+            "type": "integer"
+          },
+          "full_failed": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "player_id": {
+                  "type": "integer"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "player_id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "silo_inserted",
+          "silo_skipped",
+          "silo_failed",
+          "full_inserted",
+          "full_skipped",
+          "full_failed",
+          "failures"
+        ]
+      },
+      "AttendingEnrichPlayerPhotosBody": {
+        "type": "object",
+        "properties": {
+          "player_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "skip_existing": {
+            "type": "boolean",
+            "default": true
+          },
+          "silo_only": {
+            "type": "boolean",
+            "default": false
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000,
+            "default": 1000
+          }
+        }
+      },
+      "AttendingEnrichEspnIdsResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned_events": {
+            "type": "integer"
+          },
+          "matched_events": {
+            "type": "integer"
+          },
+          "resolved_player_ids": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "event_id": {
+                  "type": "integer"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "event_id",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned_events",
+          "matched_events",
+          "resolved_player_ids",
+          "failures"
+        ]
+      },
+      "AttendingEnrichEspnIdsBody": {
+        "type": "object",
+        "properties": {
+          "event_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100
+          }
+        }
+      },
       "SyncCompletedResponse": {
         "type": "object",
         "properties": {
@@ -18155,6 +18303,244 @@
                           "purchased_at"
                         ]
                       }
+                    },
+                    "players": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "player": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "number",
+                                "example": 42
+                              },
+                              "league": {
+                                "type": "string",
+                                "example": "mlb"
+                              },
+                              "mlb_stats_id": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ],
+                                "example": 663728
+                              },
+                              "espn_id": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "41292"
+                              },
+                              "full_name": {
+                                "type": "string",
+                                "example": "Cal Raleigh"
+                              },
+                              "primary_position": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "C"
+                              },
+                              "primary_number": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "29"
+                              },
+                              "birth_date": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "1996-11-26"
+                              },
+                              "birth_country": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "USA"
+                              },
+                              "bats": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "B"
+                              },
+                              "throws": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "R"
+                              },
+                              "primary_team_id": {
+                                "type": [
+                                  "number",
+                                  "null"
+                                ],
+                                "example": 136
+                              },
+                              "debut_date": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "2021-07-11"
+                              },
+                              "photo_silo": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "cdn_url": {
+                                    "type": "string",
+                                    "example": "https://cdn.rewind.rest/.../players/silo/123"
+                                  },
+                                  "thumbhash": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "dominant_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#1a3a6c"
+                                  },
+                                  "accent_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#c4ced4"
+                                  }
+                                },
+                                "required": [
+                                  "cdn_url",
+                                  "thumbhash",
+                                  "dominant_color",
+                                  "accent_color"
+                                ]
+                              },
+                              "photo_full": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "cdn_url": {
+                                    "type": "string",
+                                    "example": "https://cdn.rewind.rest/.../players/silo/123"
+                                  },
+                                  "thumbhash": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ]
+                                  },
+                                  "dominant_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#1a3a6c"
+                                  },
+                                  "accent_color": {
+                                    "type": [
+                                      "string",
+                                      "null"
+                                    ],
+                                    "example": "#c4ced4"
+                                  }
+                                },
+                                "required": [
+                                  "cdn_url",
+                                  "thumbhash",
+                                  "dominant_color",
+                                  "accent_color"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "league",
+                              "mlb_stats_id",
+                              "espn_id",
+                              "full_name",
+                              "primary_position",
+                              "primary_number",
+                              "birth_date",
+                              "birth_country",
+                              "bats",
+                              "throws",
+                              "primary_team_id",
+                              "debut_date",
+                              "photo_silo",
+                              "photo_full"
+                            ]
+                          },
+                          "team_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "is_home": {
+                            "type": "boolean"
+                          },
+                          "batting_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "pitching_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "fielding_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "decision": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "W"
+                          },
+                          "notable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "player",
+                          "team_id",
+                          "is_home",
+                          "batting_line",
+                          "pitching_line",
+                          "fielding_line",
+                          "decision",
+                          "notable"
+                        ]
+                      }
                     }
                   },
                   "required": [
@@ -18172,7 +18558,8 @@
                     "notes",
                     "attended",
                     "venue",
-                    "tickets"
+                    "tickets",
+                    "players"
                   ]
                 }
               }
@@ -18729,6 +19116,567 @@
           },
           "401": {
             "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/attending/players": {
+      "get": {
+        "operationId": "listAttendedPlayers",
+        "tags": [
+          "Attending"
+        ],
+        "summary": "List players you have watched play",
+        "description": "Returns players who appeared in any attended sports event. Filterable by league and team_id. Includes both photo variants when available.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "mlb"
+            },
+            "required": false,
+            "name": "league",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "example": 136
+            },
+            "required": false,
+            "name": "team_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Players",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number",
+                            "example": 42
+                          },
+                          "league": {
+                            "type": "string",
+                            "example": "mlb"
+                          },
+                          "mlb_stats_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ],
+                            "example": 663728
+                          },
+                          "espn_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "41292"
+                          },
+                          "full_name": {
+                            "type": "string",
+                            "example": "Cal Raleigh"
+                          },
+                          "primary_position": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "C"
+                          },
+                          "primary_number": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "29"
+                          },
+                          "birth_date": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "1996-11-26"
+                          },
+                          "birth_country": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "USA"
+                          },
+                          "bats": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "B"
+                          },
+                          "throws": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "R"
+                          },
+                          "primary_team_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ],
+                            "example": 136
+                          },
+                          "debut_date": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "example": "2021-07-11"
+                          },
+                          "photo_silo": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "cdn_url": {
+                                "type": "string",
+                                "example": "https://cdn.rewind.rest/.../players/silo/123"
+                              },
+                              "thumbhash": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "dominant_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#1a3a6c"
+                              },
+                              "accent_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#c4ced4"
+                              }
+                            },
+                            "required": [
+                              "cdn_url",
+                              "thumbhash",
+                              "dominant_color",
+                              "accent_color"
+                            ]
+                          },
+                          "photo_full": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "cdn_url": {
+                                "type": "string",
+                                "example": "https://cdn.rewind.rest/.../players/silo/123"
+                              },
+                              "thumbhash": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "dominant_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#1a3a6c"
+                              },
+                              "accent_color": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "example": "#c4ced4"
+                              }
+                            },
+                            "required": [
+                              "cdn_url",
+                              "thumbhash",
+                              "dominant_color",
+                              "accent_color"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "league",
+                          "mlb_stats_id",
+                          "espn_id",
+                          "full_name",
+                          "primary_position",
+                          "primary_number",
+                          "birth_date",
+                          "birth_country",
+                          "bats",
+                          "throws",
+                          "primary_team_id",
+                          "debut_date",
+                          "photo_silo",
+                          "photo_full"
+                        ]
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  },
+                  "required": [
+                    "data",
+                    "pagination"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/attending/players/{id}": {
+      "get": {
+        "operationId": "getAttendedPlayer",
+        "tags": [
+          "Attending"
+        ],
+        "summary": "Get a player you have watched play",
+        "description": "Returns the player bio with both photo variants when available, plus a list of every attended event in which they appeared along with that game's stat lines.",
+        "parameters": [
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number",
+                      "example": 42
+                    },
+                    "league": {
+                      "type": "string",
+                      "example": "mlb"
+                    },
+                    "mlb_stats_id": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "example": 663728
+                    },
+                    "espn_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "41292"
+                    },
+                    "full_name": {
+                      "type": "string",
+                      "example": "Cal Raleigh"
+                    },
+                    "primary_position": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "C"
+                    },
+                    "primary_number": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "29"
+                    },
+                    "birth_date": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "1996-11-26"
+                    },
+                    "birth_country": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "USA"
+                    },
+                    "bats": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "B"
+                    },
+                    "throws": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "R"
+                    },
+                    "primary_team_id": {
+                      "type": [
+                        "number",
+                        "null"
+                      ],
+                      "example": 136
+                    },
+                    "debut_date": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "example": "2021-07-11"
+                    },
+                    "photo_silo": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "cdn_url": {
+                          "type": "string",
+                          "example": "https://cdn.rewind.rest/.../players/silo/123"
+                        },
+                        "thumbhash": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "dominant_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#1a3a6c"
+                        },
+                        "accent_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#c4ced4"
+                        }
+                      },
+                      "required": [
+                        "cdn_url",
+                        "thumbhash",
+                        "dominant_color",
+                        "accent_color"
+                      ]
+                    },
+                    "photo_full": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "cdn_url": {
+                          "type": "string",
+                          "example": "https://cdn.rewind.rest/.../players/silo/123"
+                        },
+                        "thumbhash": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "dominant_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#1a3a6c"
+                        },
+                        "accent_color": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "example": "#c4ced4"
+                        }
+                      },
+                      "required": [
+                        "cdn_url",
+                        "thumbhash",
+                        "dominant_color",
+                        "accent_color"
+                      ]
+                    },
+                    "appearances": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "event_id": {
+                            "type": "number"
+                          },
+                          "event_date": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "team_id": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "is_home": {
+                            "type": "boolean"
+                          },
+                          "batting_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "pitching_line": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
+                          },
+                          "decision": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "notable": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "event_id",
+                          "event_date",
+                          "title",
+                          "team_id",
+                          "is_home",
+                          "batting_line",
+                          "pitching_line",
+                          "decision",
+                          "notable"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "league",
+                    "mlb_stats_id",
+                    "espn_id",
+                    "full_name",
+                    "primary_position",
+                    "primary_number",
+                    "birth_date",
+                    "birth_country",
+                    "bats",
+                    "throws",
+                    "primary_team_id",
+                    "debut_date",
+                    "photo_silo",
+                    "photo_full",
+                    "appearances"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -20695,6 +21643,112 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingEnrichBoxScoresResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-player-photos": {
+      "post": {
+        "operationId": "adminAttendingEnrichPlayerPhotos",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Backfill player photos through the image pipeline",
+        "description": "Fetches the MLB silo cutout for every player and the ESPN full-body PNG when an espn_id is known. Stores both via the existing image pipeline (R2 + thumbhash + dominant_color) keyed on (domain='attending', entity_type='player_silo'|'player_full'). Idempotent.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichPlayerPhotosBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Photo backfill completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichPlayerPhotosResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-espn-ids": {
+      "post": {
+        "operationId": "adminAttendingEnrichEspnIds",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Resolve ESPN player IDs via game summaries",
+        "description": "For each attended MLB game, hits ESPN’s schedule + summary endpoints, walks the box score, and matches each ESPN athlete to an MLB player by last_name + jersey to populate players.espn_id. Run before enrich-player-photos to unlock the ESPN full-body photo variant.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichEspnIdsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ESPN ID cross-reference completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichEspnIdsResponse"
                 }
               }
             }

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -659,4 +659,153 @@ adminAttending.openapi(enrichBoxScoresRoute, async (c) => {
   }
 });
 
+// ─── POST /v1/admin/attending/enrich-player-photos ──────────────────
+
+const EnrichPlayerPhotosBody = z
+  .object({
+    player_ids: z.array(z.number().int()).optional(),
+    skip_existing: z.boolean().optional().default(true),
+    silo_only: z.boolean().optional().default(false),
+    limit: z.number().int().min(1).max(2000).optional().default(1000),
+  })
+  .openapi('AttendingEnrichPlayerPhotosBody');
+
+const EnrichPlayerPhotosResponse = z
+  .object({
+    status: z.literal('completed'),
+    scanned: z.number().int(),
+    silo_inserted: z.number().int(),
+    silo_skipped: z.number().int(),
+    silo_failed: z.number().int(),
+    full_inserted: z.number().int(),
+    full_skipped: z.number().int(),
+    full_failed: z.number().int(),
+    failures: z.array(
+      z.object({ player_id: z.number().int(), reason: z.string() })
+    ),
+  })
+  .openapi('AttendingEnrichPlayerPhotosResponse');
+
+const enrichPlayerPhotosRoute = createRoute({
+  method: 'post',
+  path: '/admin/attending/enrich-player-photos',
+  operationId: 'adminAttendingEnrichPlayerPhotos',
+  'x-hidden': true,
+  tags: ['Admin'],
+  summary: 'Backfill player photos through the image pipeline',
+  description:
+    "Fetches the MLB silo cutout for every player and the ESPN full-body PNG when an espn_id is known. Stores both via the existing image pipeline (R2 + thumbhash + dominant_color) keyed on (domain='attending', entity_type='player_silo'|'player_full'). Idempotent.",
+  request: {
+    body: {
+      content: { 'application/json': { schema: EnrichPlayerPhotosBody } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Photo backfill completed',
+      content: {
+        'application/json': { schema: EnrichPlayerPhotosResponse },
+      },
+    },
+    ...errorResponses(401, 500),
+  },
+});
+
+adminAttending.openapi(enrichPlayerPhotosRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  type Opts = {
+    player_ids?: number[];
+    skip_existing?: boolean;
+    silo_only?: boolean;
+    limit?: number;
+  };
+  const body: Opts = await c.req.json<Opts>().catch(() => ({}) as Opts);
+
+  try {
+    const { enrichPlayerPhotos } =
+      await import('../services/attending/enrich-player-photos.js');
+    const result = await enrichPlayerPhotos(db, c.env, {
+      playerIds: body.player_ids,
+      skipExisting: body.skip_existing ?? true,
+      siloOnly: body.silo_only ?? false,
+      limit: body.limit ?? 1000,
+    });
+    return c.json({ status: 'completed' as const, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(
+      `[ERROR] POST /admin/attending/enrich-player-photos: ${message}`
+    );
+    return c.json({ error: message, status: 500 }, 500) as any;
+  }
+});
+
+// ─── POST /v1/admin/attending/enrich-espn-ids ───────────────────────
+
+const EnrichEspnIdsBody = z
+  .object({
+    event_ids: z.array(z.number().int()).optional(),
+    limit: z.number().int().min(1).max(500).optional().default(100),
+  })
+  .openapi('AttendingEnrichEspnIdsBody');
+
+const EnrichEspnIdsResponse = z
+  .object({
+    status: z.literal('completed'),
+    scanned_events: z.number().int(),
+    matched_events: z.number().int(),
+    resolved_player_ids: z.number().int(),
+    failures: z.array(
+      z.object({ event_id: z.number().int(), reason: z.string() })
+    ),
+  })
+  .openapi('AttendingEnrichEspnIdsResponse');
+
+const enrichEspnIdsRoute = createRoute({
+  method: 'post',
+  path: '/admin/attending/enrich-espn-ids',
+  operationId: 'adminAttendingEnrichEspnIds',
+  'x-hidden': true,
+  tags: ['Admin'],
+  summary: 'Resolve ESPN player IDs via game summaries',
+  description:
+    'For each attended MLB game, hits ESPN’s schedule + summary endpoints, walks the box score, and matches each ESPN athlete to an MLB player by last_name + jersey to populate players.espn_id. Run before enrich-player-photos to unlock the ESPN full-body photo variant.',
+  request: {
+    body: {
+      content: { 'application/json': { schema: EnrichEspnIdsBody } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      description: 'ESPN ID cross-reference completed',
+      content: {
+        'application/json': { schema: EnrichEspnIdsResponse },
+      },
+    },
+    ...errorResponses(401, 500),
+  },
+});
+
+adminAttending.openapi(enrichEspnIdsRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  type Opts = { event_ids?: number[]; limit?: number };
+  const body: Opts = await c.req.json<Opts>().catch(() => ({}) as Opts);
+
+  try {
+    const { enrichEspnIds } =
+      await import('../services/attending/enrich-espn-ids.js');
+    const result = await enrichEspnIds(db, {
+      eventIds: body.event_ids,
+      limit: body.limit ?? 100,
+    });
+    return c.json({ status: 'completed' as const, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`[ERROR] POST /admin/attending/enrich-espn-ids: ${message}`);
+    return c.json({ error: message, status: 500 }, 500) as any;
+  }
+});
+
 export default adminAttending;

--- a/src/routes/attending.ts
+++ b/src/routes/attending.ts
@@ -2,11 +2,14 @@ import { createRoute, z } from '@hono/zod-openapi';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import { createDb } from '../db/client.js';
 import {
+  attendedEventPlayers,
   attendedEvents,
   attendedEventTickets,
+  players,
   venues,
 } from '../db/schema/attending.js';
 import { setCache } from '../lib/cache.js';
+import { getImageAttachmentBatch } from '../lib/images.js';
 import { notFound } from '../lib/errors.js';
 import { createOpenAPIApp } from '../lib/openapi.js';
 import { errorResponses, PaginationMeta } from '../lib/schemas/common.js';
@@ -89,6 +92,48 @@ const AttendedEventSchema = z.object({
   attended: z.boolean().openapi({ example: true }),
   venue: VenueSchema.nullable(),
   tickets: z.array(TicketSchema),
+});
+
+const PlayerPhotoSchema = z.object({
+  cdn_url: z
+    .string()
+    .openapi({ example: 'https://cdn.rewind.rest/.../players/silo/123' }),
+  thumbhash: z.string().nullable(),
+  dominant_color: z.string().nullable().openapi({ example: '#1a3a6c' }),
+  accent_color: z.string().nullable().openapi({ example: '#c4ced4' }),
+});
+
+const PlayerSchema = z.object({
+  id: z.number().openapi({ example: 42 }),
+  league: z.string().openapi({ example: 'mlb' }),
+  mlb_stats_id: z.number().nullable().openapi({ example: 663728 }),
+  espn_id: z.string().nullable().openapi({ example: '41292' }),
+  full_name: z.string().openapi({ example: 'Cal Raleigh' }),
+  primary_position: z.string().nullable().openapi({ example: 'C' }),
+  primary_number: z.string().nullable().openapi({ example: '29' }),
+  birth_date: z.string().nullable().openapi({ example: '1996-11-26' }),
+  birth_country: z.string().nullable().openapi({ example: 'USA' }),
+  bats: z.string().nullable().openapi({ example: 'B' }),
+  throws: z.string().nullable().openapi({ example: 'R' }),
+  primary_team_id: z.number().nullable().openapi({ example: 136 }),
+  debut_date: z.string().nullable().openapi({ example: '2021-07-11' }),
+  photo_silo: PlayerPhotoSchema.nullable(),
+  photo_full: PlayerPhotoSchema.nullable(),
+});
+
+const AppearanceSchema = z.object({
+  player: PlayerSchema,
+  team_id: z.number().nullable(),
+  is_home: z.boolean(),
+  batting_line: z.record(z.string(), z.any()).nullable(),
+  pitching_line: z.record(z.string(), z.any()).nullable(),
+  fielding_line: z.record(z.string(), z.any()).nullable(),
+  decision: z.string().nullable().openapi({ example: 'W' }),
+  notable: z.boolean(),
+});
+
+const AttendedEventDetailSchema = AttendedEventSchema.extend({
+  players: z.array(AppearanceSchema),
 });
 
 // ─── GET /events ────────────────────────────────────────────────────
@@ -284,7 +329,7 @@ const eventDetailRoute = createRoute({
     200: {
       description: 'Event detail',
       content: {
-        'application/json': { schema: AttendedEventSchema },
+        'application/json': { schema: AttendedEventDetailSchema },
       },
     },
     ...errorResponses(401, 404),
@@ -311,6 +356,23 @@ attending.openapi(eventDetailRoute, async (c) => {
     .select()
     .from(attendedEventTickets)
     .where(eq(attendedEventTickets.eventId, e.id));
+
+  // Per-game player appearances (populated for MLB games via the
+  // box score backfill). Joined with the players table to surface
+  // bios and photo lookups.
+  const appearanceRows = await db
+    .select()
+    .from(attendedEventPlayers)
+    .leftJoin(players, eq(players.id, attendedEventPlayers.playerId))
+    .where(eq(attendedEventPlayers.eventId, e.id));
+
+  const playerIdStrings = appearanceRows
+    .map((r) => (r.players ? String(r.players.id) : null))
+    .filter((s): s is string => s !== null);
+  const [siloMap, fullMap] = await Promise.all([
+    getImageAttachmentBatch(db, 'attending', 'player_silo', playerIdStrings),
+    getImageAttachmentBatch(db, 'attending', 'player_full', playerIdStrings),
+  ]);
 
   setCache(c, 'short');
   return c.json(
@@ -352,6 +414,39 @@ attending.openapi(eventDetailRoute, async (c) => {
         currency: t.currency,
         purchased_at: t.purchasedAt,
       })),
+      players: appearanceRows
+        .filter((r) => r.players != null)
+        .map((r) => {
+          const p = r.players!;
+          const a = r.attended_event_players;
+          const eid = String(p.id);
+          return {
+            player: {
+              id: p.id,
+              league: p.league,
+              mlb_stats_id: p.mlbStatsId,
+              espn_id: p.espnId,
+              full_name: p.fullName,
+              primary_position: p.primaryPosition,
+              primary_number: p.primaryNumber,
+              birth_date: p.birthDate,
+              birth_country: p.birthCountry,
+              bats: p.bats,
+              throws: p.throws,
+              primary_team_id: p.primaryTeamId,
+              debut_date: p.debutDate,
+              photo_silo: siloMap.get(eid) ?? null,
+              photo_full: fullMap.get(eid) ?? null,
+            },
+            team_id: a.teamId,
+            is_home: a.isHome === 1,
+            batting_line: parseJson<Record<string, unknown>>(a.battingLine),
+            pitching_line: parseJson<Record<string, unknown>>(a.pitchingLine),
+            fielding_line: parseJson<Record<string, unknown>>(a.fieldingLine),
+            decision: a.decision,
+            notable: a.notable === 1,
+          };
+        }),
     },
     200
   );
@@ -605,6 +700,207 @@ attending.openapi(statsRoute, async (c) => {
       by_category: byCategory,
       by_event_type: byEventType,
       by_year: byYear,
+    },
+    200
+  );
+});
+
+// ─── GET /players ───────────────────────────────────────────────────
+
+const playersListRoute = createRoute({
+  method: 'get',
+  path: '/players',
+  operationId: 'listAttendedPlayers',
+  tags: ['Attending'],
+  summary: 'List players you have watched play',
+  description:
+    'Returns players who appeared in any attended sports event. Filterable by league and team_id. Includes both photo variants when available.',
+  request: {
+    query: z.object({
+      page: z.coerce.number().int().min(1).optional().default(1),
+      limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+      league: z.string().optional().openapi({ example: 'mlb' }),
+      team_id: z.coerce.number().int().optional().openapi({ example: 136 }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Players',
+      content: {
+        'application/json': {
+          schema: z.object({
+            data: z.array(PlayerSchema),
+            pagination: PaginationMeta,
+          }),
+        },
+      },
+    },
+    ...errorResponses(401),
+  },
+});
+
+attending.openapi(playersListRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  const { page, limit, league, team_id } = c.req.valid('query');
+  const offset = (page - 1) * limit;
+
+  const conditions = [eq(players.userId, 1)];
+  if (league) conditions.push(eq(players.league, league));
+  if (team_id) conditions.push(eq(players.primaryTeamId, team_id));
+  const where = and(...conditions);
+
+  const [{ count }] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(players)
+    .where(where);
+
+  const rows = await db
+    .select()
+    .from(players)
+    .where(where)
+    .orderBy(asc(players.lastName), asc(players.firstName))
+    .limit(limit)
+    .offset(offset);
+
+  const playerIds = rows.map((p) => String(p.id));
+  const [siloMap, fullMap] = await Promise.all([
+    getImageAttachmentBatch(db, 'attending', 'player_silo', playerIds),
+    getImageAttachmentBatch(db, 'attending', 'player_full', playerIds),
+  ]);
+
+  setCache(c, 'medium');
+  return c.json(
+    {
+      data: rows.map((p) => ({
+        id: p.id,
+        league: p.league,
+        mlb_stats_id: p.mlbStatsId,
+        espn_id: p.espnId,
+        full_name: p.fullName,
+        primary_position: p.primaryPosition,
+        primary_number: p.primaryNumber,
+        birth_date: p.birthDate,
+        birth_country: p.birthCountry,
+        bats: p.bats,
+        throws: p.throws,
+        primary_team_id: p.primaryTeamId,
+        debut_date: p.debutDate,
+        photo_silo: siloMap.get(String(p.id)) ?? null,
+        photo_full: fullMap.get(String(p.id)) ?? null,
+      })),
+      pagination: paginate(page, limit, count),
+    },
+    200
+  );
+});
+
+// ─── GET /players/:id ───────────────────────────────────────────────
+
+const playerDetailRoute = createRoute({
+  method: 'get',
+  path: '/players/{id}',
+  operationId: 'getAttendedPlayer',
+  tags: ['Attending'],
+  summary: 'Get a player you have watched play',
+  description:
+    "Returns the player bio with both photo variants when available, plus a list of every attended event in which they appeared along with that game's stat lines.",
+  request: {
+    params: z.object({
+      id: z.coerce
+        .number()
+        .int()
+        .openapi({ param: { name: 'id', in: 'path', required: true } }),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Player detail',
+      content: {
+        'application/json': {
+          schema: PlayerSchema.extend({
+            appearances: z.array(
+              z.object({
+                event_id: z.number(),
+                event_date: z.string(),
+                title: z.string(),
+                team_id: z.number().nullable(),
+                is_home: z.boolean(),
+                batting_line: z.record(z.string(), z.any()).nullable(),
+                pitching_line: z.record(z.string(), z.any()).nullable(),
+                decision: z.string().nullable(),
+                notable: z.boolean(),
+              })
+            ),
+          }),
+        },
+      },
+    },
+    ...errorResponses(401, 404),
+  },
+});
+
+attending.openapi(playerDetailRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  const { id } = c.req.valid('param');
+
+  const [p] = await db
+    .select()
+    .from(players)
+    .where(and(eq(players.id, id), eq(players.userId, 1)))
+    .limit(1);
+  if (!p) return notFound(c, 'Player not found') as any;
+
+  const eid = String(p.id);
+  const [siloMap, fullMap] = await Promise.all([
+    getImageAttachmentBatch(db, 'attending', 'player_silo', [eid]),
+    getImageAttachmentBatch(db, 'attending', 'player_full', [eid]),
+  ]);
+
+  const appearances = await db
+    .select()
+    .from(attendedEventPlayers)
+    .leftJoin(
+      attendedEvents,
+      eq(attendedEvents.id, attendedEventPlayers.eventId)
+    )
+    .where(eq(attendedEventPlayers.playerId, id))
+    .orderBy(desc(attendedEvents.eventDate));
+
+  setCache(c, 'medium');
+  return c.json(
+    {
+      id: p.id,
+      league: p.league,
+      mlb_stats_id: p.mlbStatsId,
+      espn_id: p.espnId,
+      full_name: p.fullName,
+      primary_position: p.primaryPosition,
+      primary_number: p.primaryNumber,
+      birth_date: p.birthDate,
+      birth_country: p.birthCountry,
+      bats: p.bats,
+      throws: p.throws,
+      primary_team_id: p.primaryTeamId,
+      debut_date: p.debutDate,
+      photo_silo: siloMap.get(eid) ?? null,
+      photo_full: fullMap.get(eid) ?? null,
+      appearances: appearances
+        .filter((r) => r.attended_events != null)
+        .map((r) => {
+          const a = r.attended_event_players;
+          const ev = r.attended_events!;
+          return {
+            event_id: ev.id,
+            event_date: ev.eventDate,
+            title: ev.title,
+            team_id: a.teamId,
+            is_home: a.isHome === 1,
+            batting_line: parseJson<Record<string, unknown>>(a.battingLine),
+            pitching_line: parseJson<Record<string, unknown>>(a.pitchingLine),
+            decision: a.decision,
+            notable: a.notable === 1,
+          };
+        }),
     },
     200
   );

--- a/src/services/attending/enrich-espn-ids.ts
+++ b/src/services/attending/enrich-espn-ids.ts
@@ -1,0 +1,228 @@
+// ESPN player-id cross-reference. For every attended MLB game we have
+// a Mariners-vs-X box score for, hit ESPN's game summary endpoint and
+// match each ESPN player to the MLB player by (last_name + jersey).
+// Populates `players.espn_id` so the photo pipeline can fetch the
+// ESPN full-body PNG variant.
+//
+// Approach: ESPN's schedule endpoint by team-season gives us
+// (date, ESPN gameId, opposing team). We resolve our attended events
+// to ESPN gameIds via a date+team match, then per-game pull the
+// summary endpoint and walk both rosters.
+
+import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import type { Database } from '../../db/client.js';
+import { attendedEvents, players } from '../../db/schema/attending.js';
+
+const ESPN_BASE = 'https://site.api.espn.com/apis/site/v2/sports/baseball/mlb';
+
+export interface EspnIdResult {
+  scanned_events: number;
+  matched_events: number;
+  resolved_player_ids: number;
+  failures: Array<{ event_id: number; reason: string }>;
+}
+
+interface EspnScheduleEntry {
+  id: string;
+  date: string; // ISO
+  shortName: string; // e.g. "DET @ SEA"
+  competitions?: Array<{
+    competitors?: Array<{ team?: { id?: string; abbreviation?: string } }>;
+  }>;
+}
+
+interface EspnSummaryAthlete {
+  athlete: {
+    id: string;
+    displayName?: string;
+    fullName?: string;
+    lastName?: string;
+    jersey?: string;
+    position?: { abbreviation?: string };
+  };
+}
+
+interface EspnSummaryStatGroup {
+  athletes?: EspnSummaryAthlete[];
+}
+
+interface EspnSummary {
+  boxscore?: {
+    players?: Array<{
+      team?: { id?: string };
+      statistics?: EspnSummaryStatGroup[];
+    }>;
+  };
+}
+
+export interface EspnIdOptions {
+  // Limit which events to scan. By default scans all MLB games where
+  // any associated player still lacks an espn_id.
+  eventIds?: number[];
+  limit?: number;
+}
+
+export async function enrichEspnIds(
+  db: Database,
+  opts: EspnIdOptions = {}
+): Promise<EspnIdResult> {
+  const { eventIds, limit = 100 } = opts;
+  const result: EspnIdResult = {
+    scanned_events: 0,
+    matched_events: 0,
+    resolved_player_ids: 0,
+    failures: [],
+  };
+
+  const events = await db
+    .select()
+    .from(attendedEvents)
+    .where(
+      and(
+        eq(attendedEvents.eventType, 'mlb_game'),
+        eq(attendedEvents.externalSource, 'mlb_stats_api'),
+        isNotNull(attendedEvents.externalId)
+      )
+    )
+    .limit(limit);
+
+  // Cache schedule lookups per (team, year) — many of our games share a
+  // year/team combo, so we do at most one fetch per Mariners season.
+  const scheduleCache = new Map<string, EspnScheduleEntry[]>();
+
+  for (const ev of events) {
+    if (eventIds && !eventIds.includes(ev.id)) continue;
+    result.scanned_events++;
+
+    const eventDate = ev.eventDate;
+    const year = eventDate.slice(0, 4);
+    const cacheKey = `sea-${year}`;
+
+    let schedule = scheduleCache.get(cacheKey);
+    if (!schedule) {
+      try {
+        schedule = await fetchEspnSchedule('sea', parseInt(year, 10));
+        scheduleCache.set(cacheKey, schedule);
+      } catch (err) {
+        result.failures.push({
+          event_id: ev.id,
+          reason: `schedule fetch: ${err instanceof Error ? err.message : String(err)}`,
+        });
+        continue;
+      }
+    }
+
+    // Match by date — ESPN's date is ISO with TZ, our event_date is YYYY-MM-DD.
+    const espnGame = schedule.find((g) => g.date.slice(0, 10) === eventDate);
+    if (!espnGame) {
+      result.failures.push({
+        event_id: ev.id,
+        reason: `no ESPN game on ${eventDate}`,
+      });
+      continue;
+    }
+
+    let summary: EspnSummary;
+    try {
+      summary = await fetchEspnSummary(espnGame.id);
+    } catch (err) {
+      result.failures.push({
+        event_id: ev.id,
+        reason: `summary fetch: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    result.matched_events++;
+    const matched = await matchAndPersistEspnIds(db, summary);
+    result.resolved_player_ids += matched;
+  }
+
+  return result;
+}
+
+async function fetchEspnSchedule(
+  teamSlug: string,
+  season: number
+): Promise<EspnScheduleEntry[]> {
+  const res = await fetch(
+    `${ESPN_BASE}/teams/${teamSlug}/schedule?season=${season}`
+  );
+  if (!res.ok) throw new Error(`ESPN schedule ${res.status}`);
+  const body = (await res.json()) as { events?: EspnScheduleEntry[] };
+  return body.events ?? [];
+}
+
+async function fetchEspnSummary(gameId: string): Promise<EspnSummary> {
+  const res = await fetch(`${ESPN_BASE}/summary?event=${gameId}`);
+  if (!res.ok) throw new Error(`ESPN summary ${gameId} ${res.status}`);
+  return (await res.json()) as EspnSummary;
+}
+
+/**
+ * Walk the box score in the ESPN summary and match each athlete to a
+ * player row by last_name + jersey (and league=mlb). Updates
+ * `players.espn_id` when we find a confident match. Returns count of
+ * newly-resolved espn_ids.
+ *
+ * Match rules (must all hold):
+ *   - players.league = 'mlb'
+ *   - players.last_name (lowercase) === athlete.lastName (lowercase)
+ *   - players.primary_number === athlete.jersey  (when both present)
+ *   - players.espn_id is currently NULL (don't overwrite existing)
+ */
+async function matchAndPersistEspnIds(
+  db: Database,
+  summary: EspnSummary
+): Promise<number> {
+  let count = 0;
+  const teams = summary.boxscore?.players ?? [];
+  for (const teamGroup of teams) {
+    for (const grp of teamGroup.statistics ?? []) {
+      for (const item of grp.athletes ?? []) {
+        const a = item.athlete;
+        if (!a?.id) continue;
+        const lastName = (
+          a.lastName ?? extractLastName(a.fullName ?? a.displayName ?? '')
+        ).toLowerCase();
+        const jersey = a.jersey ?? null;
+        if (!lastName) continue;
+
+        // Find a candidate match. We use raw SQL for case-insensitive last
+        // name comparison (drizzle's eq() is case-sensitive).
+        const candidates = await db
+          .select({ id: players.id, primaryNumber: players.primaryNumber })
+          .from(players)
+          .where(
+            and(
+              eq(players.league, 'mlb'),
+              isNull(players.espnId),
+              sql`lower(${players.lastName}) = ${lastName}`
+            )
+          );
+
+        let match: { id: number; primaryNumber: string | null } | null = null;
+        if (candidates.length === 1) {
+          match = candidates[0];
+        } else if (candidates.length > 1 && jersey) {
+          // Disambiguate by jersey when multiple players share a last name.
+          match = candidates.find((c) => c.primaryNumber === jersey) ?? null;
+        }
+        if (!match) continue;
+
+        await db
+          .update(players)
+          .set({ espnId: a.id, updatedAt: new Date().toISOString() })
+          .where(eq(players.id, match.id));
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+function extractLastName(fullName: string): string {
+  if (!fullName) return '';
+  const parts = fullName.trim().split(/\s+/);
+  return parts[parts.length - 1] ?? '';
+}

--- a/src/services/attending/enrich-player-photos.ts
+++ b/src/services/attending/enrich-player-photos.ts
@@ -1,0 +1,166 @@
+// Player photo backfill: for every row in `players`, fetch the MLB
+// silo cutout PNG (head/shoulders, transparent) and the ESPN full-body
+// PNG (when an ESPN id is known) through the existing image pipeline.
+// Stores both in R2 with thumbhash + dominant_color, keyed on
+//   (domain='attending', entity_type='player_silo'|'player_full',
+//    entity_id=String(players.id))
+// Idempotent — pipeline records already in `images` are skipped.
+
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../../db/client.js';
+import { players } from '../../db/schema/attending.js';
+import { images } from '../../db/schema/system.js';
+import type { PipelineEnv } from '../images/pipeline.js';
+import { runPipeline } from '../images/pipeline.js';
+
+export interface PlayerPhotoOptions {
+  // Limit to a specific subset of player IDs (db PK, not mlb_stats_id).
+  playerIds?: number[];
+  // Default: skip players who already have a silo image in `images`.
+  skipExisting?: boolean;
+  // Hard cap on players processed in one run.
+  limit?: number;
+  // When true, skip the ESPN/full variant even when espn_id is present.
+  siloOnly?: boolean;
+}
+
+export interface PlayerPhotoResult {
+  scanned: number;
+  silo_inserted: number;
+  silo_skipped: number;
+  silo_failed: number;
+  full_inserted: number;
+  full_skipped: number;
+  full_failed: number;
+  failures: Array<{ player_id: number; reason: string }>;
+}
+
+const SILO_URL_TEMPLATE =
+  'https://img.mlbstatic.com/mlb-photos/image/upload/d_people:generic:headshot:silo:current.png/r_max/w_360,q_auto:best/v1/people/{ID}/headshot/silo/current';
+
+const ESPN_FULL_URL_TEMPLATE =
+  'https://a.espncdn.com/combiner/i?img=/i/headshots/mlb/players/full/{ID}.png&h=400&w=400&scale=crop';
+
+export async function enrichPlayerPhotos(
+  db: Database,
+  env: PipelineEnv,
+  opts: PlayerPhotoOptions = {}
+): Promise<PlayerPhotoResult> {
+  const {
+    playerIds,
+    skipExisting = true,
+    limit = 1000,
+    siloOnly = false,
+  } = opts;
+
+  const result: PlayerPhotoResult = {
+    scanned: 0,
+    silo_inserted: 0,
+    silo_skipped: 0,
+    silo_failed: 0,
+    full_inserted: 0,
+    full_skipped: 0,
+    full_failed: 0,
+    failures: [],
+  };
+
+  const rows = await db.select().from(players).limit(limit);
+  const filtered = playerIds
+    ? rows.filter((r) => playerIds.includes(r.id))
+    : rows;
+
+  for (const p of filtered) {
+    if (!p.mlbStatsId) continue;
+    result.scanned++;
+    const entityId = String(p.id);
+
+    // Silo: every player with an mlb_stats_id gets one.
+    const siloOutcome = await fetchAndStore(
+      db,
+      env,
+      'player_silo',
+      entityId,
+      SILO_URL_TEMPLATE.replace('{ID}', String(p.mlbStatsId)),
+      skipExisting
+    );
+    if (siloOutcome === 'inserted') result.silo_inserted++;
+    else if (siloOutcome === 'skipped') result.silo_skipped++;
+    else {
+      result.silo_failed++;
+      result.failures.push({
+        player_id: p.id,
+        reason: `silo: ${siloOutcome}`,
+      });
+    }
+
+    // Full: only when we have an ESPN id (resolved by the cross-reference
+    // sync). No id → leave the slot empty; consumer falls back to silo.
+    if (!siloOnly && p.espnId) {
+      const fullOutcome = await fetchAndStore(
+        db,
+        env,
+        'player_full',
+        entityId,
+        ESPN_FULL_URL_TEMPLATE.replace('{ID}', p.espnId),
+        skipExisting
+      );
+      if (fullOutcome === 'inserted') result.full_inserted++;
+      else if (fullOutcome === 'skipped') result.full_skipped++;
+      else {
+        result.full_failed++;
+        result.failures.push({
+          player_id: p.id,
+          reason: `full: ${fullOutcome}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+type StoreOutcome = 'inserted' | 'skipped' | string;
+
+async function fetchAndStore(
+  db: Database,
+  env: PipelineEnv,
+  entityType: 'player_silo' | 'player_full',
+  entityId: string,
+  url: string,
+  skipExisting: boolean
+): Promise<StoreOutcome> {
+  if (skipExisting) {
+    const existing = await db
+      .select({ id: images.id })
+      .from(images)
+      .where(
+        and(
+          eq(images.domain, 'attending'),
+          eq(images.entityType, entityType),
+          eq(images.entityId, entityId)
+        )
+      )
+      .limit(1);
+    if (existing.length > 0) return 'skipped';
+  }
+
+  try {
+    const result = await runPipeline(
+      db,
+      env,
+      {
+        domain: 'attending',
+        entityType,
+        entityId,
+      },
+      {
+        prefetchedCandidates: [
+          { source: entityType, url, width: null, height: null },
+        ],
+      }
+    );
+    return result ? 'inserted' : 'pipeline returned null';
+  } catch (err) {
+    return `pipeline error: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}


### PR DESCRIPTION
## Summary

PR B of the player work. Builds on PR A (#50, schema + box score sync) to add photos and the API surface.

### What lands

1. **ESPN player-id cross-reference** (\`enrich-espn-ids.ts\`) — for each attended MLB game, fetch ESPN's team schedule for the season, match by date+team to find the ESPN gameId, hit the summary endpoint, and walk the boxscore. Match each ESPN athlete to an MLB player by last_name + jersey, populate \`players.espn_id\`. Cached per (team, year).
2. **Player photo backfill** (\`enrich-player-photos.ts\`) — for every player row, fetch the **MLB silo cutout** PNG (head/shoulders, transparent, ~130KB at 360px). For players with an \`espn_id\`, also fetch the **ESPN full-body** PNG (longer crop, also transparent). Both stored via the existing image pipeline (R2 + thumbhash + dominant_color), keyed on \`(domain='attending', entity_type='player_silo'|'player_full', entity_id=String(players.id))\`.
3. **Two new admin endpoints:**
   - \`POST /v1/admin/attending/enrich-espn-ids\`
   - \`POST /v1/admin/attending/enrich-player-photos\`
4. **API surface:**
   - \`GET /v1/attending/events/{id}\` now returns a \`players\` array with bio + both photo variants + per-game stat lines + decision.
   - \`GET /v1/attending/players\` — browse players you've watched play, filterable by \`league\` and \`team_id\`.
   - \`GET /v1/attending/players/{id}\` — player detail with every attended event in which they appeared, including stat lines per game.

### Capture-broadly bias preserved

When both photos resolve, both are saved. Consumers pick at render time (silo for tight grids, full for hero spots). Players without an ESPN id resolved fall back gracefully — \`photo_full\` is null, \`photo_silo\` always populated.

### Test plan

- [x] All 864 vitest cases pass
- [x] Type check, ESLint, OpenAPI spec all green
- [ ] Post-merge: \`POST /v1/admin/attending/enrich-espn-ids\` to populate ESPN IDs for the ~150 unique players in attended Mariners games
- [ ] Post-merge: \`POST /v1/admin/attending/enrich-player-photos\` to fetch silo + full photos and run them through the image pipeline
- [ ] Verify a few event detail responses include populated \`players\` arrays with photo URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)