### PR TITLE
fix(attending): extract player last_name + PT/UTC date drift

### DIFF
--- a/src/services/attending/enrich-espn-ids.ts
+++ b/src/services/attending/enrich-espn-ids.ts
@@ -112,8 +112,16 @@ export async function enrichEspnIds(
       }
     }
 
-    // Match by date — ESPN's date is ISO with TZ, our event_date is YYYY-MM-DD.
-    const espnGame = schedule.find((g) => g.date.slice(0, 10) === eventDate);
+    // ESPN stores dates in UTC; our event_date is the venue-local date
+    // (Pacific for Mariners home games). Late-PT games (~7pm+) cross
+    // midnight UTC, so the UTC date is one day AFTER our stored date.
+    // Match against both eventDate and eventDate+1.
+    const eventDatePlusOne = addOneDay(eventDate);
+    const espnGame = schedule.find(
+      (g) =>
+        g.date.slice(0, 10) === eventDate ||
+        g.date.slice(0, 10) === eventDatePlusOne
+    );
     if (!espnGame) {
       result.failures.push({
         event_id: ev.id,
@@ -223,6 +231,13 @@ async function matchAndPersistEspnIds(
 
 function extractLastName(fullName: string): string {
   if (!fullName) return '';
-  const parts = fullName.trim().split(/\s+/);
+  const stripped = fullName.trim().replace(/\s+(Jr\.?|Sr\.?|II|III|IV)$/i, '');
+  const parts = stripped.split(/\s+/);
   return parts[parts.length - 1] ?? '';
+}
+
+function addOneDay(yyyyMmDd: string): string {
+  const d = new Date(yyyyMmDd + 'T12:00:00Z');
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
 }

--- a/src/services/sports/mlb-boxscore.test.ts
+++ b/src/services/sports/mlb-boxscore.test.ts
@@ -328,3 +328,105 @@ describe('fetchMlbBoxScore', () => {
     });
   });
 });
+
+describe('splitFullName fallback', () => {
+  // Indirectly tested via toBio when person.firstName/lastName absent.
+  // We verify the extracted bio carries a populated last_name.
+  it('extracts last_name when only fullName is present', async () => {
+    const minimalFixture = {
+      teams: {
+        home: {
+          team: { id: 136, name: 'Seattle Mariners' },
+          pitchers: [],
+          players: {
+            ID596142: {
+              person: { id: 596142, fullName: 'Cal Raleigh' },
+              position: { abbreviation: 'C' },
+              stats: {
+                batting: {
+                  gamesPlayed: 1,
+                  atBats: 4,
+                  runs: 0,
+                  hits: 2,
+                  rbi: 0,
+                  baseOnBalls: 0,
+                  strikeOuts: 0,
+                  homeRuns: 0,
+                  doubles: 0,
+                  triples: 0,
+                  stolenBases: 0,
+                  hitByPitch: 0,
+                  plateAppearances: 4,
+                  totalBases: 0,
+                  leftOnBase: 0,
+                },
+              },
+            },
+          },
+        },
+        away: {
+          team: { id: 116, name: 'Detroit Tigers' },
+          pitchers: [],
+          players: {},
+        },
+      },
+    };
+    const minimalFeed = { gamePk: 1, gameData: {}, liveData: {} };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes('/boxscore'))
+        return new Response(JSON.stringify(minimalFixture), { status: 200 });
+      if (u.includes('/feed/live'))
+        return new Response(JSON.stringify(minimalFeed), { status: 200 });
+      return new Response('not found', { status: 404 });
+    });
+
+    const data = await fetchMlbBoxScore(1);
+    expect(data).not.toBeNull();
+    const raleigh = data!.appearances.find(
+      (a) => a.player.mlb_stats_id === 596142
+    );
+    expect(raleigh!.player.last_name).toBe('Raleigh');
+    expect(raleigh!.player.first_name).toBe('Cal');
+  });
+
+  it('strips suffixes like Jr / III from last name', async () => {
+    const fixture = {
+      teams: {
+        home: {
+          team: { id: 136 },
+          pitchers: [],
+          players: {
+            ID1: {
+              person: { id: 1, fullName: 'Vladimir Guerrero Jr.' },
+              position: { abbreviation: '1B' },
+              stats: { batting: { gamesPlayed: 1, atBats: 4 } },
+            },
+            ID2: {
+              person: { id: 2, fullName: 'Cal Ripken III' },
+              position: { abbreviation: 'SS' },
+              stats: { batting: { gamesPlayed: 1, atBats: 4 } },
+            },
+          },
+        },
+        away: { team: { id: 0 }, pitchers: [], players: {} },
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes('/boxscore'))
+        return new Response(JSON.stringify(fixture), { status: 200 });
+      return new Response(
+        JSON.stringify({ gamePk: 1, gameData: {}, liveData: {} }),
+        { status: 200 }
+      );
+    });
+
+    const data = await fetchMlbBoxScore(1);
+    const vlad = data!.appearances.find((a) => a.player.mlb_stats_id === 1);
+    const cal = data!.appearances.find((a) => a.player.mlb_stats_id === 2);
+    expect(vlad!.player.last_name).toBe('Guerrero');
+    expect(vlad!.player.first_name).toBe('Vladimir');
+    expect(cal!.player.last_name).toBe('Ripken');
+  });
+});

--- a/src/services/sports/mlb-boxscore.ts
+++ b/src/services/sports/mlb-boxscore.ts
@@ -287,11 +287,16 @@ function toAppearance(
 
 function toBio(raw: RawPlayer): MlbPlayerBio {
   const p = raw.person;
+  // Boxscore endpoint typically returns only `person.fullName` —
+  // first/last aren't split by default. Fall back to whitespace-splitting
+  // the full name so name-based joins (ESPN cross-ref) have something
+  // to match on.
+  const split = splitFullName(p.fullName);
   return {
     mlb_stats_id: p.id,
     full_name: p.fullName,
-    first_name: p.firstName ?? null,
-    last_name: p.lastName ?? null,
+    first_name: p.firstName ?? split.first,
+    last_name: p.lastName ?? split.last,
     primary_position: raw.position?.abbreviation ?? null,
     primary_number: raw.jerseyNumber ?? p.primaryNumber ?? null,
     birth_date: p.birthDate ?? null,
@@ -300,6 +305,30 @@ function toBio(raw: RawPlayer): MlbPlayerBio {
     bats: p.batSide?.code ?? null,
     throws: p.pitchHand?.code ?? null,
     debut_date: p.mlbDebutDate ?? null,
+  };
+}
+
+/**
+ * Naive first/last split. "Cal Raleigh" → ("Cal", "Raleigh"). For
+ * compound last names ("J.D. Martinez", "Vladimir Guerrero Jr.") the
+ * MLB hydrate=person path gives us authoritative fields; this splitter
+ * is the fallback when only fullName is present.
+ */
+function splitFullName(full: string | undefined): {
+  first: string | null;
+  last: string | null;
+} {
+  if (!full) return { first: null, last: null };
+  const trimmed = full.trim();
+  if (!trimmed) return { first: null, last: null };
+  // Strip common suffixes off the end so they don't end up as "last name".
+  const suffixes = /\s+(Jr\.?|Sr\.?|II|III|IV)$/i;
+  const stripped = trimmed.replace(suffixes, '').trim();
+  const parts = stripped.split(/\s+/);
+  if (parts.length === 1) return { first: null, last: parts[0] };
+  return {
+    first: parts.slice(0, -1).join(' '),
+    last: parts[parts.length - 1],
   };
 }
 


### PR DESCRIPTION
## Summary

Two bugs that surfaced when running PR #51's ESPN cross-reference against real data:

1. **Players had \`last_name = NULL\`** for all 839 rows. The MLB Stats boxscore endpoint returns \`person.fullName\` only — first/last aren't split unless \`?hydrate=person\` is passed. Our parser left both null, which broke the ESPN cross-ref join (matches by lowercase last_name → 0 resolved on 28 matched events). Fix: derive first/last from fullName via whitespace split, with suffix-stripping so \`"Vladimir Guerrero Jr."\` → \`("Vladimir Guerrero", "Guerrero")\` and \`"Cal Ripken III"\` → \`(..., "Ripken")\`.

2. **Date match missed 10 late Pacific home games.** ESPN stores dates in UTC. A 7:10pm PT first pitch crosses midnight UTC, so the UTC date is one day AFTER our stored Pacific event_date. Fix: try both \`eventDate\` and \`eventDate+1\` when looking up the ESPN game.

## Test plan

- [x] All 866 vitest cases pass (2 new tests for the split helper)
- [x] Type check, ESLint, OpenAPI spec all green
- [ ] Post-merge: re-run \`enrich-boxscores\` (UPDATEs the 839 players with proper last_name)
- [ ] Post-merge: re-run \`enrich-espn-ids\` (should resolve ~150 ESPN IDs now)
- [ ] Post-merge: \`enrich-player-photos\` (silo for all, full for ESPN-matched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)