### PR TITLE
fix(attending): require first-name match + dedupe ESPN ID assignment

### DIFF
--- a/src/services/attending/enrich-espn-ids.ts
+++ b/src/services/attending/enrich-espn-ids.ts
@@ -257,21 +257,37 @@ async function matchAndPersistEspnIds(
         if (candidates.length === 0) continue;
 
         let match: (typeof candidates)[number] | null = null;
-        if (candidates.length === 1) {
-          match = candidates[0];
-        } else if (firstName) {
-          // Try first-name match within the last-name candidates.
+        if (firstName) {
+          // Require a first-name match when ESPN gave us one. Avoids
+          // the trap where a single leftover same-last-name candidate
+          // gets a wrong ID just because it was the only one left.
           match =
             candidates.find(
               (c) => c.first_name && normalize(c.first_name) === firstName
             ) ?? null;
+        } else if (candidates.length === 1) {
+          // No first name from ESPN — accept the single candidate.
+          match = candidates[0];
         }
-        // Final fallback: jersey match if ESPN provided one and we
-        // still have ambiguity.
+        // Last-resort jersey match (rare since ESPN summaries usually
+        // omit jerseys).
         if (!match && a.jersey) {
           match = candidates.find((c) => c.jersey === a.jersey) ?? null;
         }
         if (!match) continue;
+
+        // Belt-and-suspenders: check the espn_id isn't already taken
+        // by a different player. Without this, a same-last-name
+        // collision in a *different* game can blow up the unique
+        // (league, espn_id) index later in the run.
+        const existing = await db
+          .select({ id: players.id })
+          .from(players)
+          .where(and(eq(players.league, 'mlb'), eq(players.espnId, a.id)))
+          .limit(1);
+        if (existing.length > 0 && existing[0].id !== match.player_id) {
+          continue;
+        }
 
         await db
           .update(players)


### PR DESCRIPTION
## Summary

After PR #53 the game-scoped matcher still tripped a unique-index violation. Two cascading bugs:

1. **Single leftover candidate ≠ correct match.** When several MLB players share a last name in a game's roster and one already had an espn_id from a previous game, the matcher's "filter out already-matched" pass left exactly one candidate — and matched the next ESPN athlete to that lone candidate even when first names disagreed. Edwin Diaz already mapped → Jorge Diaz left over → Edwin's ESPN ID got tried against Jorge → unique constraint violation.

2. **No cross-player dedupe before write.** Even when the matcher picks the wrong player locally, a pre-write check should catch "this espn_id already belongs to someone else" before issuing the conflicting UPDATE.

### Fix

- When ESPN provides a first name, **REQUIRE first+last match**. Don't fall back to "single candidate" without first-name confirmation.
- Single-candidate match only when ESPN gave us no first name (rare).
- Pre-write SELECT to verify the espn_id isn't claimed by a different player. Skip rather than violate.

### Run-flow post-merge

1. Clear stale espn_ids: \`UPDATE players SET espn_id = NULL WHERE league='mlb'\` (already done locally; need to re-run after merge for cleanliness)
2. \`POST /v1/admin/attending/enrich-espn-ids\` — expect clean completion with high resolution rate
3. \`POST /v1/admin/attending/enrich-player-photos\` — fills the new \`player_full\` slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)