### PR TITLE
feat(feed): integrate attending domain into cross-domain feed

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -1018,6 +1018,47 @@
           }
         }
       },
+      "AttendingBackfillFeedResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "inserted": {
+            "type": "integer"
+          },
+          "skipped": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "inserted",
+          "skipped"
+        ]
+      },
+      "AttendingBackfillFeedBody": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000,
+            "default": 2000
+          },
+          "dry_run": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
       "SyncCompletedResponse": {
         "type": "object",
         "properties": {
@@ -21749,6 +21790,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingEnrichEspnIdsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/backfill-feed": {
+      "post": {
+        "operationId": "adminAttendingBackfillFeed",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Backfill activity_feed rows for existing attended events",
+        "description": "One-shot backfill: walks `attended_events`, builds an activity-feed row for each, and inserts via the standard cross-domain insert path. Idempotent — feed-side dedupe on (domain, source_id) means re-running is safe. Used once on PR rollout to populate historical events; new events get feed rows automatically via loadCanonicalEvent.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingBackfillFeedBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Backfill completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingBackfillFeedResponse"
                 }
               }
             }

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -1018,6 +1018,47 @@
           }
         }
       },
+      "AttendingBackfillFeedResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "inserted": {
+            "type": "integer"
+          },
+          "skipped": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "inserted",
+          "skipped"
+        ]
+      },
+      "AttendingBackfillFeedBody": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 2000,
+            "default": 2000
+          },
+          "dry_run": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
       "SyncCompletedResponse": {
         "type": "object",
         "properties": {
@@ -21749,6 +21790,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingEnrichEspnIdsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/backfill-feed": {
+      "post": {
+        "operationId": "adminAttendingBackfillFeed",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Backfill activity_feed rows for existing attended events",
+        "description": "One-shot backfill: walks `attended_events`, builds an activity-feed row for each, and inserts via the standard cross-domain insert path. Idempotent — feed-side dedupe on (domain, source_id) means re-running is safe. Used once on PR rollout to populate historical events; new events get feed rows automatically via loadCanonicalEvent.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingBackfillFeedBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Backfill completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingBackfillFeedResponse"
                 }
               }
             }

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -808,4 +808,66 @@ adminAttending.openapi(enrichEspnIdsRoute, async (c) => {
   }
 });
 
+// ─── POST /v1/admin/attending/backfill-feed ─────────────────────────
+
+const BackfillFeedBody = z
+  .object({
+    limit: z.number().int().min(1).max(2000).optional().default(2000),
+    dry_run: z.boolean().optional().default(false),
+  })
+  .openapi('AttendingBackfillFeedBody');
+
+const BackfillFeedResponse = z
+  .object({
+    status: z.literal('completed'),
+    scanned: z.number().int(),
+    inserted: z.number().int(),
+    skipped: z.number().int(),
+  })
+  .openapi('AttendingBackfillFeedResponse');
+
+const backfillFeedRoute = createRoute({
+  method: 'post',
+  path: '/admin/attending/backfill-feed',
+  operationId: 'adminAttendingBackfillFeed',
+  'x-hidden': true,
+  tags: ['Admin'],
+  summary: 'Backfill activity_feed rows for existing attended events',
+  description:
+    'One-shot backfill: walks `attended_events`, builds an activity-feed row for each, and inserts via the standard cross-domain insert path. Idempotent — feed-side dedupe on (domain, source_id) means re-running is safe. Used once on PR rollout to populate historical events; new events get feed rows automatically via loadCanonicalEvent.',
+  request: {
+    body: {
+      content: { 'application/json': { schema: BackfillFeedBody } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      description: 'Backfill completed',
+      content: { 'application/json': { schema: BackfillFeedResponse } },
+    },
+    ...errorResponses(401, 500),
+  },
+});
+
+adminAttending.openapi(backfillFeedRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  type Opts = { limit?: number; dry_run?: boolean };
+  const body: Opts = await c.req.json<Opts>().catch(() => ({}) as Opts);
+
+  try {
+    const { backfillAttendingFeed } =
+      await import('../services/attending/backfill-feed.js');
+    const result = await backfillAttendingFeed(db, {
+      limit: body.limit ?? 2000,
+      dryRun: body.dry_run ?? false,
+    });
+    return c.json({ status: 'completed' as const, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`[ERROR] POST /admin/attending/backfill-feed: ${message}`);
+    return c.json({ error: message, status: 500 }, 500) as any;
+  }
+});
+
 export default adminAttending;

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -9,7 +9,13 @@ import { badRequest } from '../lib/errors.js';
 import { createOpenAPIApp } from '../lib/openapi.js';
 import { errorResponses } from '../lib/schemas/common.js';
 
-const VALID_DOMAINS = ['listening', 'running', 'watching', 'collecting'];
+const VALID_DOMAINS = [
+  'listening',
+  'running',
+  'watching',
+  'collecting',
+  'attending',
+];
 
 const feed = createOpenAPIApp();
 

--- a/src/services/attending/backfill-feed.ts
+++ b/src/services/attending/backfill-feed.ts
@@ -1,0 +1,103 @@
+// One-shot backfill that walks attended_events and writes a row in
+// activity_feed for each. Used after the activity-feed integration
+// PR ships to populate historical events; new events get feed rows
+// inline via loadCanonicalEvent.
+//
+// Idempotent — insertFeedItems dedupes on (domain, source_id), so
+// re-running is safe.
+
+import { and, eq, inArray } from 'drizzle-orm';
+import type { Database } from '../../db/client.js';
+import { attendedEvents, venues } from '../../db/schema/attending.js';
+import { activityFeed } from '../../db/schema/system.js';
+import { insertFeedItems } from '../../routes/feed.js';
+import { feedItemFromRow } from './feed-items.js';
+
+export interface BackfillFeedOptions {
+  limit?: number;
+  dryRun?: boolean;
+}
+
+export interface BackfillFeedResult {
+  scanned: number;
+  inserted: number;
+  skipped: number;
+}
+
+export async function backfillAttendingFeed(
+  db: Database,
+  opts: BackfillFeedOptions = {}
+): Promise<BackfillFeedResult> {
+  const { limit = 2000, dryRun = false } = opts;
+
+  const rows = await db
+    .select({
+      id: attendedEvents.id,
+      category: attendedEvents.category,
+      event_type: attendedEvents.eventType,
+      event_date: attendedEvents.eventDate,
+      event_datetime: attendedEvents.eventDatetime,
+      title: attendedEvents.title,
+      subtitle: attendedEvents.subtitle,
+      attended: attendedEvents.attended,
+      event_data: attendedEvents.eventData,
+      venue_name: venues.name,
+    })
+    .from(attendedEvents)
+    .leftJoin(venues, eq(venues.id, attendedEvents.venueId))
+    .where(eq(attendedEvents.userId, 1))
+    .limit(limit);
+
+  if (dryRun) {
+    return { scanned: rows.length, inserted: 0, skipped: rows.length };
+  }
+
+  const items = rows.map((r) =>
+    feedItemFromRow({
+      id: r.id,
+      category: r.category,
+      event_type: r.event_type,
+      event_date: r.event_date,
+      event_datetime: r.event_datetime,
+      title: r.title,
+      subtitle: r.subtitle,
+      attended: r.attended,
+      venue_name: r.venue_name ?? null,
+      event_data: r.event_data ? safeJson(r.event_data) : null,
+    })
+  );
+
+  // Pre-count what's already in the feed so we can report
+  // inserted vs skipped — insertFeedItems dedupes silently and returns
+  // void, so we mirror its lookup here.
+  const sourceIds = items.map((i) => i.sourceId);
+  const existing = sourceIds.length
+    ? await db
+        .select({ source_id: activityFeed.sourceId })
+        .from(activityFeed)
+        .where(
+          and(
+            eq(activityFeed.domain, 'attending'),
+            inArray(activityFeed.sourceId, sourceIds)
+          )
+        )
+    : [];
+  const existingSet = new Set(existing.map((e) => e.source_id));
+  const inserted = items.filter((i) => !existingSet.has(i.sourceId)).length;
+
+  await insertFeedItems(db, items);
+
+  return {
+    scanned: rows.length,
+    inserted,
+    skipped: rows.length - inserted,
+  };
+}
+
+function safeJson(s: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(s) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/src/services/attending/feed-items.ts
+++ b/src/services/attending/feed-items.ts
@@ -1,0 +1,123 @@
+// Convert attended events into activity-feed rows. The cross-domain
+// /v1/feed endpoint reads from the unified `activity_feed` table; each
+// domain is responsible for inserting its own items via `afterSync` /
+// `insertFeedItems` after a sync (or on demand).
+//
+// Source-id discipline: every feed row dedupes on (domain, source_id),
+// so we use a stable per-event key — `attending:event:{id}`. Re-running
+// the backfill (or re-loading the same event) is idempotent.
+
+import type { FeedItem } from '../../lib/after-sync.js';
+import type { CanonicalEvent } from './enrich.js';
+
+interface AttendedEventRow {
+  id: number;
+  category: string;
+  event_type: string;
+  event_date: string;
+  event_datetime: string | null;
+  title: string;
+  subtitle: string | null;
+  attended: number; // 0/1
+  venue_name: string | null;
+  event_data: Record<string, unknown> | null;
+}
+
+/**
+ * Build a feed item from a freshly-loaded canonical event. Used inline
+ * by `loadCanonicalEvent` so the activity feed is up to date the
+ * moment a new event lands.
+ */
+export function feedItemFromCanonical(
+  eventId: number,
+  canonical: CanonicalEvent,
+  venueName: string | null
+): FeedItem {
+  return formatFeedItem({
+    id: eventId,
+    category: canonical.category,
+    event_type: canonical.event_type,
+    event_date: canonical.event_date,
+    event_datetime: canonical.event_datetime,
+    title: canonical.title,
+    subtitle: canonical.subtitle,
+    attended: 1,
+    venue_name: venueName,
+    event_data: canonical.event_data,
+  });
+}
+
+/**
+ * Build a feed item from a stored event row (used by the backfill
+ * endpoint that walks existing rows in attended_events).
+ */
+export function feedItemFromRow(row: AttendedEventRow): FeedItem {
+  return formatFeedItem(row);
+}
+
+function formatFeedItem(ev: AttendedEventRow): FeedItem {
+  // occurredAt: prefer the precise event_datetime when present,
+  // otherwise the date-only event_date with midday fallback so it
+  // sorts cleanly against scrobbles/runs/watches in the feed.
+  const occurredAt =
+    ev.event_datetime && /T\d{2}:\d{2}/.test(ev.event_datetime)
+      ? ev.event_datetime
+      : `${ev.event_date}T12:00:00.000Z`;
+
+  // Title: lead with category-appropriate verb. Sports → "Saw Mariners
+  // vs Astros" etc.; concerts → "Saw Glass Animals". Keep the actual
+  // matchup/show name in the title body so the feed row reads
+  // self-contained without venue.
+  const verb = verbForCategory(ev.category);
+  const title = `${verb} ${ev.title}`;
+
+  // Subtitle: prefer the score line (event.subtitle is "Mariners 4,
+  // Astros 2" for sports). Fall back to venue name; empty otherwise.
+  const subtitle = ev.subtitle ?? ev.venue_name ?? undefined;
+
+  // Useful for downstream consumers who want richer rendering without
+  // joining back to the canonical row.
+  const metadata: Record<string, unknown> = {
+    event_type: ev.event_type,
+    venue: ev.venue_name,
+    attended: ev.attended === 1,
+  };
+  if (ev.event_data && typeof ev.event_data === 'object') {
+    const ed = ev.event_data as Record<string, unknown>;
+    if (ed.my_team_won != null) metadata.my_team_won = ed.my_team_won;
+    if (ed.attendance != null) metadata.attendance = ed.attendance;
+  }
+
+  return {
+    domain: 'attending',
+    eventType: eventTypeForFeed(ev.event_type, ev.attended === 1),
+    occurredAt,
+    title,
+    subtitle,
+    sourceId: `event:${ev.id}`,
+    metadata,
+  };
+}
+
+function verbForCategory(category: string): string {
+  switch (category) {
+    case 'sports':
+      return 'Saw';
+    case 'music':
+      return 'Saw';
+    case 'arts':
+      return 'Attended';
+    default:
+      return 'Attended';
+  }
+}
+
+function eventTypeForFeed(_eventType: string, attended: boolean): string {
+  // Distinguish no-shows so consumers can filter / style differently.
+  // Most events use `event_attended` to mirror the existing one-noun
+  // pattern from listening (`new_artist`, `new_album`). The first arg
+  // is plumbed for future use (e.g. concert vs game styling) but
+  // currently unused.
+  if (!attended) return 'event_missed';
+  return 'event_attended';
+}

--- a/src/services/attending/load.ts
+++ b/src/services/attending/load.ts
@@ -22,8 +22,11 @@ import {
   attendedEventSources,
   attendedEventTickets,
   attendedEventPerformers,
+  venues,
 } from '../../db/schema/attending.js';
+import { insertFeedItem } from '../../routes/feed.js';
 import type { CanonicalEvent } from './enrich.js';
+import { feedItemFromCanonical } from './feed-items.js';
 import type { ParsedReservation } from './parse-jsonld.js';
 
 export interface LoadResult {
@@ -220,6 +223,33 @@ export async function loadCanonicalEvent(
           eq(attendedEventSources.sourceRef, s.source_ref)
         )
       );
+  }
+
+  // Cross-domain feed integration. Insert a row in activity_feed
+  // keyed on `attending:event:{id}` so this event shows up in the
+  // unified /v1/feed and /v1/feed/on-this-day surfaces alongside
+  // scrobbles/runs/watches/articles. Idempotent — re-running this
+  // path no-ops via the (domain, source_id) unique index.
+  let venueName: string | null = null;
+  if (canonical.venue_id != null) {
+    const [v] = await db
+      .select({ name: venues.name })
+      .from(venues)
+      .where(eq(venues.id, canonical.venue_id))
+      .limit(1);
+    if (v) venueName = v.name;
+  }
+  try {
+    await insertFeedItem(
+      db,
+      feedItemFromCanonical(eventId, canonical, venueName)
+    );
+  } catch (err) {
+    // Non-fatal — feed insert mirrors the lastfm/strava patterns where
+    // failures are logged but don't block the canonical write.
+    console.log(
+      `[WARN] attending feed insert failed for event ${eventId}: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   return {


### PR DESCRIPTION
## Summary

Adds the attending domain to \`/v1/feed\` and \`/v1/feed/on-this-day\`. Each attended event becomes a feed row keyed on \`attending:event:{id}\`, joining scrobbles/runs/watches/articles/collecting in the unified timeline.

### Item shape

\`\`\`json
{
  "domain": "attending",
  "event_type": "event_attended",
  "occurred_at": "2024-08-08T01:42:00Z",
  "title": "Saw Seattle Mariners vs. Detroit Tigers",
  "subtitle": "Mariners 2, Tigers 6",
  "metadata": {
    "event_type": "mlb_game",
    "venue": "T-Mobile Park",
    "attended": true,
    "my_team_won": false,
    "attendance": 26033
  }
}
\`\`\`

### Two integration paths

1. **Live (loadCanonicalEvent)** — every new event written by the sync pipeline gets a feed row inline. Non-fatal failure mode mirrors lastfm/strava patterns.
2. **Backfill (admin)** — \`POST /v1/admin/attending/backfill-feed\` walks every existing \`attended_events\` row (currently 263) and inserts feed items. Idempotent: feed-side dedupe on \`(domain, source_id)\` makes re-runs safe.

\`/v1/feed/domain/attending\` filters cleanly via the \`'attending'\` addition to \`VALID_DOMAINS\`. \`on-this-day\` works for free since it queries \`activity_feed\` directly.

### Test plan

- [x] All 866 vitest cases pass
- [x] Type check, ESLint, OpenAPI snapshot all green
- [ ] Post-merge: \`POST /v1/admin/attending/backfill-feed\` to populate the 263 historical events
- [ ] Verify \`GET /v1/feed?limit=20\` includes attending rows mixed with other domains
- [ ] Verify \`GET /v1/feed/on-this-day?month=8&day=7\` includes that day's Mariners game alongside scrobbles/runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)