### PR TITLE
fix(feed): chunk both dedupe + INSERT in insertFeedItems

### DIFF
--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -440,6 +440,14 @@ export async function insertFeedItem(
 
 /**
  * Batch insert activity feed items. Called by domain sync services.
+ *
+ * D1 caps bound parameters per query (~256 in practice). Both the
+ * dedupe SELECT (`IN (?, ?, ...)`) and the multi-row INSERT
+ * (`VALUES (?, ?, ?, ...), (...)`) can blow past that with large
+ * batches — sport-domain backfills routinely hand us 200+ items.
+ * Chunk both operations: 200 source_ids per dedupe lookup, 20 rows
+ * per INSERT (20 × 11 columns ≈ 220 params, comfortably under the
+ * cap with headroom).
  */
 export async function insertFeedItems(
   db: ReturnType<typeof drizzle>,
@@ -457,30 +465,39 @@ export async function insertFeedItems(
 ) {
   if (items.length === 0) return;
 
-  // Get existing sourceIds for these domains to skip duplicates
+  const SELECT_CHUNK = 200; // dedupe IN-list cap
+  const INSERT_CHUNK = 20; // INSERT VALUES row cap (× 11 cols ≈ 220 params)
+
   const domains = [...new Set(items.map((i) => i.domain))];
+
+  // Chunked dedupe lookup: walk source_ids in batches and accumulate
+  // the keys already present in activity_feed.
+  const existingSet = new Set<string>();
   const sourceIds = items.map((i) => i.sourceId);
-
-  const existing = await db
-    .select({
-      sourceId: activityFeed.sourceId,
-      domain: activityFeed.domain,
-    })
-    .from(activityFeed)
-    .where(
-      and(
-        sql`${activityFeed.domain} IN (${sql.join(
-          domains.map((d) => sql`${d}`),
-          sql`, `
-        )})`,
-        sql`${activityFeed.sourceId} IN (${sql.join(
-          sourceIds.map((s) => sql`${s}`),
-          sql`, `
-        )})`
-      )
-    );
-
-  const existingSet = new Set(existing.map((e) => `${e.domain}:${e.sourceId}`));
+  for (let i = 0; i < sourceIds.length; i += SELECT_CHUNK) {
+    const chunk = sourceIds.slice(i, i + SELECT_CHUNK);
+    const existing = await db
+      .select({
+        sourceId: activityFeed.sourceId,
+        domain: activityFeed.domain,
+      })
+      .from(activityFeed)
+      .where(
+        and(
+          sql`${activityFeed.domain} IN (${sql.join(
+            domains.map((d) => sql`${d}`),
+            sql`, `
+          )})`,
+          sql`${activityFeed.sourceId} IN (${sql.join(
+            chunk.map((s) => sql`${s}`),
+            sql`, `
+          )})`
+        )
+      );
+    for (const e of existing) {
+      existingSet.add(`${e.domain}:${e.sourceId}`);
+    }
+  }
 
   const newItems = items.filter(
     (i) => !existingSet.has(`${i.domain}:${i.sourceId}`)
@@ -489,20 +506,22 @@ export async function insertFeedItems(
   if (newItems.length === 0) return;
 
   const now = new Date().toISOString();
-  await db.insert(activityFeed).values(
-    newItems.map((item) => ({
-      userId: item.userId ?? 1,
-      domain: item.domain,
-      eventType: item.eventType,
-      occurredAt: item.occurredAt,
-      title: item.title,
-      subtitle: item.subtitle ?? null,
-      imageKey: item.imageKey ?? null,
-      sourceId: item.sourceId,
-      metadata: item.metadata ? JSON.stringify(item.metadata) : null,
-      createdAt: now,
-    }))
-  );
+  const rows = newItems.map((item) => ({
+    userId: item.userId ?? 1,
+    domain: item.domain,
+    eventType: item.eventType,
+    occurredAt: item.occurredAt,
+    title: item.title,
+    subtitle: item.subtitle ?? null,
+    imageKey: item.imageKey ?? null,
+    sourceId: item.sourceId,
+    metadata: item.metadata ? JSON.stringify(item.metadata) : null,
+    createdAt: now,
+  }));
+
+  for (let i = 0; i < rows.length; i += INSERT_CHUNK) {
+    await db.insert(activityFeed).values(rows.slice(i, i + INSERT_CHUNK));
+  }
 }
 
 export default feed;

--- a/src/services/attending/backfill-feed.ts
+++ b/src/services/attending/backfill-feed.ts
@@ -67,30 +67,30 @@ export async function backfillAttendingFeed(
     })
   );
 
-  // D1 caps bound parameters per query, and `insertFeedItems` does an
-  // IN-list dedupe lookup that grows with the batch. Walk in chunks of
-  // 75 source_ids so we stay well under the limit (100 is the D1
-  // ceiling we've hit in practice). Per-chunk: pre-count existing
-  // rows, then call insertFeedItems (which re-does the lookup
-  // internally — small redundancy but it keeps the count accurate).
-  const CHUNK = 75;
-  let inserted = 0;
-  for (let i = 0; i < items.length; i += CHUNK) {
-    const chunk = items.slice(i, i + CHUNK);
-    const sourceIds = chunk.map((c) => c.sourceId);
+  // Pre-count rows that already exist so we can report
+  // inserted vs skipped — insertFeedItems dedupes silently and
+  // returns void. Chunk the IN-list lookup to stay under D1's
+  // per-query parameter cap.
+  const SELECT_CHUNK = 200;
+  const existingSet = new Set<string>();
+  for (let i = 0; i < items.length; i += SELECT_CHUNK) {
+    const chunk = items.slice(i, i + SELECT_CHUNK).map((c) => c.sourceId);
     const existing = await db
       .select({ source_id: activityFeed.sourceId })
       .from(activityFeed)
       .where(
         and(
           eq(activityFeed.domain, 'attending'),
-          inArray(activityFeed.sourceId, sourceIds)
+          inArray(activityFeed.sourceId, chunk)
         )
       );
-    const existingSet = new Set(existing.map((e) => e.source_id));
-    inserted += chunk.filter((c) => !existingSet.has(c.sourceId)).length;
-    await insertFeedItems(db, chunk);
+    for (const e of existing) existingSet.add(e.source_id);
   }
+  const inserted = items.filter((i) => !existingSet.has(i.sourceId)).length;
+
+  // insertFeedItems handles its own internal chunking for both the
+  // dedupe SELECT and the INSERT VALUES (D1 param cap).
+  await insertFeedItems(db, items);
 
   return {
     scanned: rows.length,


### PR DESCRIPTION
## Summary

D1 caps bound parameters per query (~256). The attending backfill (263 events in one batch) hit it twice:
1. Dedupe SELECT IN-list — 264 source_ids in one query → 500
2. Multi-row INSERT VALUES — 75 rows × 11 cols = 825 params → 500

Both now chunk in the shared \`insertFeedItems\`:
- SELECT: 200 source_ids per IN-list lookup
- INSERT: 20 rows per VALUES (~220 params, headroom under 256)

Generic fix benefits every domain that hits the unified feed insert path. Service-level chunking from PR #61 rolls back since the underlying helper now handles it.

## Test plan

- [x] All 866 tests pass
- [ ] Post-merge: re-run \`backfill-feed\` and verify clean completion + attending domain shows up in \`/v1/feed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)