### PR TITLE
fix(feed): tighter D1 chunks + drop attending pre-count

### DIFF
--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -465,8 +465,10 @@ export async function insertFeedItems(
 ) {
   if (items.length === 0) return;
 
-  const SELECT_CHUNK = 200; // dedupe IN-list cap
-  const INSERT_CHUNK = 20; // INSERT VALUES row cap (× 11 cols ≈ 220 params)
+  // D1's effective per-query param cap is around 100 in practice;
+  // 200-source-id IN-lists still tripped the planner. Stay well below.
+  const SELECT_CHUNK = 80; // dedupe IN-list cap (+ 1 for domain)
+  const INSERT_CHUNK = 8; // INSERT VALUES row cap (8 × 11 cols = 88 params)
 
   const domains = [...new Set(items.map((i) => i.domain))];
 

--- a/src/services/attending/backfill-feed.ts
+++ b/src/services/attending/backfill-feed.ts
@@ -6,7 +6,7 @@
 // Idempotent — insertFeedItems dedupes on (domain, source_id), so
 // re-running is safe.
 
-import { and, eq, inArray } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { Database } from '../../db/client.js';
 import { attendedEvents, venues } from '../../db/schema/attending.js';
 import { activityFeed } from '../../db/schema/system.js';
@@ -67,36 +67,29 @@ export async function backfillAttendingFeed(
     })
   );
 
-  // Pre-count rows that already exist so we can report
-  // inserted vs skipped — insertFeedItems dedupes silently and
-  // returns void. Chunk the IN-list lookup to stay under D1's
-  // per-query parameter cap.
-  const SELECT_CHUNK = 200;
-  const existingSet = new Set<string>();
-  for (let i = 0; i < items.length; i += SELECT_CHUNK) {
-    const chunk = items.slice(i, i + SELECT_CHUNK).map((c) => c.sourceId);
-    const existing = await db
-      .select({ source_id: activityFeed.sourceId })
-      .from(activityFeed)
-      .where(
-        and(
-          eq(activityFeed.domain, 'attending'),
-          inArray(activityFeed.sourceId, chunk)
-        )
-      );
-    for (const e of existing) existingSet.add(e.source_id);
-  }
-  const inserted = items.filter((i) => !existingSet.has(i.sourceId)).length;
-
   // insertFeedItems handles its own internal chunking for both the
-  // dedupe SELECT and the INSERT VALUES (D1 param cap).
+  // dedupe SELECT and the INSERT VALUES under D1's param cap. We
+  // don't track inserted-vs-skipped for the response — the helper
+  // returns void. Callers who need the split can re-query feed
+  // counts before/after.
+  const before = await countAttendingFeedRows(db);
   await insertFeedItems(db, items);
+  const after = await countAttendingFeedRows(db);
+  const inserted = after - before;
 
   return {
     scanned: rows.length,
     inserted,
     skipped: rows.length - inserted,
   };
+}
+
+async function countAttendingFeedRows(db: Database): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(activityFeed)
+    .where(eq(activityFeed.domain, 'attending'));
+  return row?.count ?? 0;
 }
 
 function safeJson(s: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

D1's effective bound-param cap is around 100 in practice (lower than the documented 256). The 200-row chunks from PR #62 still tripped the planner during the attending backfill.

- \`insertFeedItems\`: SELECT_CHUNK 200 → 80, INSERT_CHUNK 20 → 8 (8 rows × 11 cols = 88 params).
- \`backfill-feed.ts\`: drop the pre-count IN-list lookup entirely. Replace with cheap \`count(*)\` before/after to populate the inserted/skipped response fields. Removes the param-heavy query that was blowing up.

## Test plan

- [x] All 866 tests pass
- [ ] Post-merge: \`POST /v1/admin/attending/backfill-feed\` completes cleanly + populates 263 attending rows in \`activity_feed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)