### PR TITLE
fix(feed): add attending to domain-filter Zod enum

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -19937,7 +19937,8 @@
                 "listening",
                 "running",
                 "watching",
-                "collecting"
+                "collecting",
+                "attending"
               ],
               "description": "Activity domain to filter by",
               "example": "listening"

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -19937,7 +19937,8 @@
                 "listening",
                 "running",
                 "watching",
-                "collecting"
+                "collecting",
+                "attending"
               ],
               "description": "Activity domain to filter by",
               "example": "listening"

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -62,7 +62,13 @@ const FeedResponseSchema = z.object({
 
 const DomainParamSchema = z.object({
   domain: z
-    .enum(['listening', 'running', 'watching', 'collecting'] as const)
+    .enum([
+      'listening',
+      'running',
+      'watching',
+      'collecting',
+      'attending',
+    ] as const)
     .openapi({
       description: 'Activity domain to filter by',
       example: 'listening',


### PR DESCRIPTION
PR #57 added 'attending' to VALID_DOMAINS but missed the separate Zod enum on /v1/feed/domain/{domain}. Adds it + regenerates the OpenAPI snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)