### PR TITLE
feat(attending): search-based ESPN player-id resolver for the long tail

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -1018,6 +1018,88 @@
           }
         }
       },
+      "AttendingEnrichEspnIdsBySearchResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "resolved_unique": {
+            "type": "integer"
+          },
+          "resolved_disambiguated": {
+            "type": "integer"
+          },
+          "multi_unresolved": {
+            "type": "integer"
+          },
+          "zero_match": {
+            "type": "integer"
+          },
+          "collision_skipped": {
+            "type": "integer"
+          },
+          "errors": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "player_id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "player_id",
+                "name",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "resolved_unique",
+          "resolved_disambiguated",
+          "multi_unresolved",
+          "zero_match",
+          "collision_skipped",
+          "errors",
+          "failures"
+        ]
+      },
+      "AttendingEnrichEspnIdsBySearchBody": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 500
+          },
+          "throttle_ms": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 2000,
+            "default": 50
+          }
+        }
+      },
       "AttendingBackfillFeedResponse": {
         "type": "object",
         "properties": {
@@ -21791,6 +21873,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingEnrichEspnIdsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-espn-ids-by-search": {
+      "post": {
+        "operationId": "adminAttendingEnrichEspnIdsBySearch",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Resolve ESPN player IDs via name search",
+        "description": "For every players row missing espn_id, hits ESPN site search and disambiguates by position class when a name returns multiple MLB hits. Complements enrich-espn-ids (game-summary scoped) by catching relief pitchers and bench players who do not appear in ESPN summary.athletes lists.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichEspnIdsBySearchBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ESPN ID search resolution completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichEspnIdsBySearchResponse"
                 }
               }
             }

--- a/docs/projects/attending-domain/NEXT-STEPS.md
+++ b/docs/projects/attending-domain/NEXT-STEPS.md
@@ -1,101 +1,116 @@
 # Attending Domain — Next Steps
 
-Snapshot at the close of the build session: **193 events live in prod**, infrastructure complete, PR #43 merged to main, daily cron scheduled. What's left is data curation by you and (optionally) a few follow-up projects.
+Snapshot at the close of the 2026-04-26 build session: **263 attended events live in prod**, full per-game player stats + photos for MLB games, MCP tools + season-grid card UI shipped, activity feed integrated. What's left is data curation by you and a couple of follow-up projects (separate design docs).
 
-## State as of 2026-04-25
+## State as of 2026-04-26
 
 ```
-Total events: 193
-  concert       : 128
-  mlb_game      :  37
-  ncaaf_game    :  15
+Total events: 263
+  concert       : 135   (135 incl. arts events misclassified as concert)
+  ncaaf_game    :  70
+  mlb_game      :  45
   nfl_game      :   9
   wnba_game     :   3
   ncaab_game    :   1
 
-Year distribution (full): 2016:2, 2017:8, 2018:5, 2019:11,
-                         2021:?, 2022:?, 2023:?, 2024:21,
-                         2025:31, 2026:6  (etc.)
+Mariners by year:
+  2014: 2   2017: 2   2019: 1   2022: 4
+  2023: 9   2024: 9   2025: 14  2026: 4
+  (gap years: 2018, 2020, 2021)
 
-Mariners by year: 2017:2, 2022:4, 2023:8, 2024:8, 2025:13, 2026:2
+UW football by season:
+  2007–2010: ~6 home games each (Block A undergrad)
+  2013: ~7 home games (grad year)
+  2022, 2023, 2025: ~6 home games each (return-to-Seattle)
+  Block B (Cal/Stanford road games 2011–2016): not yet curated
 
-Pending source rows (mostly notifications, not real gaps): 663
+Per-game player data (MLB):
+  839 unique players seen
+  1,977 game appearances with batting/pitching/fielding lines
+  100% silo photos (839/839)
+   60% full ESPN photos (499/839 — relief pitchers / bench guys
+                          rarely appear in ESPN summaries)
+
+Activity feed: 263 attending rows in /v1/feed
+MCP tools:
+  get_attended_events, get_attended_event, get_attended_season,
+  get_attended_player, get_attending_stats
+  + interactive season-grid card in MCP Apps clients
 ```
 
 ## Things you do (priority order)
 
-### 1. Tomorrow morning: confirm cron tick
+### 1. Curate Mariners coverage — `scripts/data/manual-attending-mariners.json`
 
-```bash
-curl https://api.rewind.rest/v1/health/sync \
-  -H "Authorization: Bearer $API_KEY" | jq '.domains.attending'
-```
+Empty scaffold. Email recovery got us 45 Mariners games; gap years are 2018 / 2020 / 2021. Two options documented in the file's `_notes`:
 
-Expect `last_sync` after 4 AM PT and `status: completed`. If `status: failed`, re-run admin sync manually and check `error` field.
+- **Per-game entries** for specific games you remember outside the email trail. Most realistic for the gap years (friend-tickets path).
+- **Season-shorthand `all_home`** — only if you attended overwhelmingly. Probably not the right fit unless any season was a season-ticket year.
 
-### 2. Curate UW football coverage — `scripts/data/manual-attending-uw-football.json`
-
-Already scaffolded with 8 starter rows (2007–2010 + 2013 + 2022/2023/2025 all-home shorthand). To complete:
-
-- **Add Block B per-game rows** for SF-decade away games at Cal/Stanford 2010–2016 (one per year, alternating). Wikipedia "YYYY Washington Huskies football team" pages give the schedule — pick the Bay Area road game per year. ~5–7 entries.
-- **Optional: per-season exceptions.** Edit `exceptions: ["YYYY-MM-DD"]` for any home game you actually missed (sick, traveling). Server flips `attended=0`.
-- **Optional: 2024 Apple Cup**. Currently shows W=5 L=1 because the calendar entry loaded as attended=1. Add `{ event_type: 'ncaaf_game', team_id: 264, season: 2024, attendance: 'all_home', exceptions: ['2024-09-14'] }` to flip it (or use the review-surface promote endpoint with `attended: 0`).
-- **Optional: 2021** — UW's pandemic-affected season. Add or skip per your recall.
-
-To run:
+Run:
 
 ```bash
 REWIND_ADMIN_KEY=$ADMIN_KEY npx tsx scripts/tools/import-manual-attending.ts \
-  scripts/data/manual-attending-uw-football.json --remote
+  scripts/data/manual-attending-mariners.json --remote
 ```
 
-Server expands season-shorthand rows to ~40 events (one per home game per season).
+### 2. Curate UW football Block B — `scripts/data/manual-attending-uw-football.json`
 
-### 3. Curate Mariners coverage — `scripts/data/manual-attending-mariners.json`
+Already loaded with 8 season-shorthand rows (Block A: 2007–2010 + 2013, return-to-Seattle: 2022/2023/2025) → 56 events. Still missing:
 
-Already scaffolded but empty. Email recovery got us 37 Mariners games; gaps are uneven (2021 is 0). Two options documented in the file's `_notes`:
+- **Block B per-game rows** for SF-decade away games at Cal/Stanford 2011–2016. Wikipedia "YYYY Washington Huskies football team" pages give the schedule — pick the Bay Area road game per year. ~5 entries.
+- **Optional: 2024 Apple Cup correction**. Currently 5-1 attended record assumes you went; you mentioned you DID go to the Lumen Field game so the data is correct as-is. Skip.
+- **Optional: 2021** — UW's pandemic-affected season. Add or skip per recall.
 
-- **Per-game entries** for specific games you remember outside the email trail.
-- **Season-shorthand `all_home`** — only if you attended overwhelmingly (most of 81 home games), since you'd have to list misses.
+Same import command as above with the UW filename.
 
-Most likely the gaps are individual purchases via the friend-tickets path — per-game is the realistic option.
+### 3. Confirm cron tick (any morning)
+
+```bash
+curl https://api.rewind.rest/v1/health/sync -H "Authorization: Bearer $API_KEY" \
+  | jq '.domains.attending'
+```
+
+Expect `last_sync` after 4 AM PT and `status: completed`. Cron has been firing daily without issues — this is just a sanity check whenever you remember.
 
 ### 4. Optional: review pending source rows
 
-663 source rows still pending. Most are subject-rejected (marketing, transfers) or non-confirmation types. To browse:
+665 source rows still pending. Most are subject-rejected marketing or non-confirmation noise. The deep-sweep + game-scoped reprocess work this session moved the real ones into canonical events; what remains is mostly long-tail noise.
 
 ```bash
 curl 'https://api.rewind.rest/v1/admin/attending/pending?limit=50' \
   -H "Authorization: Bearer $API_KEY"
 ```
 
-For each that's a real missed event, either:
+For real missed events: `POST /v1/admin/attending/sources/:id/promote` with optional overrides, or `/reject` for confirmed noise.
 
-- `POST /v1/admin/attending/sources/:id/promote` with optional `{ event_date, location, ... }` overrides
-- `POST /v1/admin/attending/sources/:id/reject` to hard-delete the row
+## Things on you in other repos
 
-Skip this entirely if you don't care about the long tail.
+- **Portfolio site Mariners 2024 page** — the original motivation. Use `GET /v1/attending/seasons/mlb/2024` to drive a season-grid view; the API responds with attended games + W/L + per-game player photos. Lives in `pat-portfolio` (separate repo).
+- **Rotate the leaked admin key** — `rw_admin_4a70c8d41d5f0688e1a26d07b8425bbf` is committed in 6 pre-existing main commits (`318df90`, `7e7b8e3`, `11e8929`, `4ee9b89`, `9f9e2bb`, `1d97102`). Worth rotating; details in repo issues.
 
-## Things that wait (follow-up projects, separate design docs)
+## Things that wait (follow-up projects, see open GitHub issues)
 
-| Project                                                                                                                        | Priority | Effort                        | Value                                                           |
-| ------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------------------- | --------------------------------------------------------------- |
-| **MCP tools for attending** (`get_attended_events`, `get_attended_season`, `get_attending_stats`)                              | High     | ~1 evening                    | "What Mariners games did I attend in 2023?" via Claude Desktop. |
-| **Activity feed integration** — surface attended events in `/v1/feed` alongside scrobbles/runs/watches                         | Med      | ~2 hours                      | Cross-domain unified timeline.                                  |
-| **Image enrichment** — team logos (TheSportsDB), venue photos (Google Places), performer photos (cross-link to lastfm_artists) | Med      | ~1 evening                    | Visual layer for portfolio.                                     |
-| **Portfolio site Mariners 2024 page**                                                                                          | High     | ~1 evening (in pat-portfolio) | The original motivation.                                        |
-| **Year-in-review for attending**                                                                                               | Low      | ~half evening                 | Annual recap.                                                   |
+| Project                                                                     | Priority | Effort        | Value                                            |
+| --------------------------------------------------------------------------- | -------- | ------------- | ------------------------------------------------ |
+| **Year-in-review for attending** (`/v1/attending/year/{year}`)              | Low      | ~half evening | Annual recap. Mirrors listening/running pattern. |
+| **NFL/NBA/WNBA box scores** (extend the MLB enrichment to other leagues)    | Med      | ~2 evenings   | Per-game player stats for the 13 non-MLB games.  |
+| **Concert performer photos** (cross-link `lastfm_artist_id` to image)       | Med      | ~half evening | Concert detail responses gain artist photos.     |
+| **Improve concert event_data** (setlists, opener vs headliner discovery)    | Low      | ~1 evening    | Setlist.fm enrichment beyond what shipped in v1. |
+| **Backfill ESPN photos for unmatched players** (~340 mostly-relief pitcher) | Low      | unclear       | Marginal — ESPN summaries don't include them.    |
 
 ## Risks worth watching
 
 - **OAuth refresh token revocation**: unverified-app status means Google could flag the app for review. Mitigation: re-run `setup-google.ts --remote` when needed, ~5 min.
-- **ESPN endpoint stability**: unsupported, could disappear. Detection: cron metrics show drop in `parsed/fetched` ratio. Switch to TheSportsDB or paid alternative would take ~half evening.
-- **Cron failure cascading**: if 4 AM cron fails for a transient reason, `shouldRetry()` retries up to 2x. After that it stops; `/v1/health/sync` shows the failed state. Manual recovery: `POST /v1/admin/sync/attending` with mode=incremental.
+- **ESPN endpoint stability**: unofficial, could disappear. Detection: cron metrics show drop in parsed/fetched ratio. Fallback path: TheSportsDB or paid alternative, ~half evening to swap.
+- **MLB Stats API stability**: same caveat — undocumented but stable since ~2018. Used by community libraries (pybaseball, etc.).
+- **Cron failure cascading**: if 4 AM cron fails for a transient reason, `shouldRetry()` retries up to 2x. After that it stops; `/v1/health/sync` shows the failed state. Manual recovery: `POST /v1/admin/sync/attending` with `mode=incremental`.
+- **D1 parameter cap**: ~100 in practice. The chunked feed insert handles it. Future bulk admin endpoints should chunk similarly — this caught us twice during the activity-feed integration.
 
-## Things explicitly out of scope for v1 (deferred indefinitely)
+## Out of scope for v1 (deferred indefinitely)
 
-- Per-vendor parsers for: drafthouse.com (movie tickets — overlap with watching domain), regaltickets.com, cityboxoffice.com, sffilm.org, sfsketchfest.com, ticketfly.com (deprecated). All low-volume in your inbox; reprocess endpoint can pick them up later if a parser ships.
-- UW Athletics direct ticketing (`gohuskies.com` / `fan-one.com`) — these turned out to be marketing/gameday newsletters, not purchase confirmations. UW routes sales through Ticketmaster.
+- Per-vendor parsers for low-volume sources: drafthouse.com (overlap with watching domain), regaltickets.com, cityboxoffice.com, sffilm.org, sfsketchfest.com, ticketfly.com (deprecated). Reprocess endpoint can pick them up later if a parser ships.
+- UW Athletics direct ticketing (`gohuskies.com` / `fan-one.com`) — turned out to be marketing/gameday newsletters, not purchase confirmations. UW sales route through Ticketmaster.
 - Multi-account Google OAuth (work + personal Gmail).
 - Resale/refund modeling (the `attended` boolean is enough for "did I go").
 

--- a/docs/projects/attending-domain/README.md
+++ b/docs/projects/attending-domain/README.md
@@ -32,6 +32,10 @@ Branch `worktree-attending-domain`:
 | 9     | Backfill execution — DONE (auto-track). Migrations applied to remote D1, Google secrets set, prod token seeded, smoke-test passed (216k Gmail messages accessible). Calendar full pull: 11030 scanned, 59 matched, 57 inserted. Gmail full pull: 694 scanned, 20 parsed, 665 source rows captured. Manual UW imports (9.6/9.7) gated on user curation.                                                                                        |
 | 3.5   | Per-vendor parsers + reprocess — DONE. Five parsers shipped (Ticket Club, Ticketmaster, AXS, Vivid Seats, StubHub) each handling multiple template generations from real fixture inspection. Body-storage gap fixed (now persists both body_text and body_html). Reprocess endpoint re-runs parsers over pending sources with optional Gmail refetch. Subject gate hardened with 14 new reject patterns. **Result: 61 → 103 events in prod**. |
 | 9.5   | Deep email sweep + Eventbrite parser — DONE. Broad Gmail query revealed ~500 confirmation-pattern emails outside our 6-vendor allowlist. Eventbrite alone had 66+ confirmations (mostly tech meetups + smaller concerts). Eventbrite parser shipped + added to vendor allowlist. **Result: 103 → 193 events in prod**. Final breakdown: concerts 128, mlb_game 37, ncaaf_game 15, nfl_game 9, wnba_game 3, ncaab_game 1.                      |
+| 10    | MCP tools + season-grid card UI — DONE (#55). Five tools shipped: `get_attended_events`, `get_attended_season` (with interactive card), `get_attended_event`, `get_attended_player`, `get_attending_stats`. Season-grid card renders W/L badges + per-game player chips with silo headshots in MCP Apps clients via `ui://rewind/attended-season.html`. Manifest snapshots + docs updated.                                                    |
+| 11    | Activity feed integration — DONE (#57, #61, #62, #63, #64). All 263 attended events now appear in `/v1/feed`, `/v1/feed/on-this-day`, and `/v1/feed/domain/attending`. Inline insert via `loadCanonicalEvent` + one-shot backfill via `POST /v1/admin/attending/backfill-feed`. `insertFeedItems` chunks both the dedupe SELECT (CHUNK=80) and INSERT VALUES (CHUNK=8) under D1's ~100-param effective cap.                                   |
+| 12    | Per-game player stats + photos (MLB) — DONE (#51, #52, #53, #54). Boxscore enrichment writes per-player batting/pitching/fielding lines to `attended_event_players`. Cross-references ESPN player summaries by game-scoped roster intersection. **839 unique players seen, 1,977 game appearances. 100% silo photos (839/839). 60% full ESPN photos (499/839)** — relief pitchers / bench guys rarely surface in ESPN summaries.              |
+| 13    | Backfill execution → 263 events in prod. Mariners 45 games (2014–2026 with gap years 2018/2020/2021), UW football 70 games via Block A/C season-shorthand. Concerts 135. Total now 263 — see `NEXT-STEPS.md` for the punch list and per-year breakdown.                                                                                                                                                                                       |
 
 This project covers the data-ingestion pipeline: Google OAuth foundation, Calendar + Gmail extractors, sports/concert enrichment, dedupe/load, cron wiring, and one-time backfill execution.
 
@@ -188,10 +192,20 @@ These are non-blocking — defaults are picked; flag during implementation if an
 
 ## Follow-up projects
 
-These are intentionally **not** in this project. Each is a clean follow-up once the data is flowing:
+These are intentionally **not** in this project. Each is a clean follow-up once the data is flowing. Items shipped during the session-wrap pass are kept as a record; remaining items are tracked in open GitHub issues.
 
-- **MCP tools for attending** (`get_attended_events`, `get_attended_season`, `get_attended_event_details`, `get_attending_stats`). Mechanical port of existing tools.
-- **Activity feed integration** — surface attended events alongside scrobbles/runs/watches in `/v1/feed`.
-- **Image pipeline for the new domain** — team logos (TheSportsDB free), venue photos (Google Places photo API or manual), performer photos (already covered when `lastfm_artist_id` is populated).
-- **Portfolio site Mariners 2024 page** in `pat-portfolio` — fetches MLB Stats API + Rewind `/attending/seasons/mlb/2024` + renders the grid.
-- **Year-in-review for attending** — most-attended team, total tickets bought, total spent, etc.
+**Shipped:**
+
+- ✓ **MCP tools for attending** — `get_attended_events`, `get_attended_season`, `get_attended_event`, `get_attended_player`, `get_attending_stats` + interactive season-grid card UI (#55).
+- ✓ **Activity feed integration** — attended events now in `/v1/feed`, `/v1/feed/on-this-day`, and `/v1/feed/domain/attending` (#57, #61–#64).
+- ✓ **Player image pipeline (MLB)** — silo headshots + ESPN full headshots stored in `images` and rendered inline in MCP card (#51–#54).
+
+**Still pending — see open GitHub issues:**
+
+- **Year-in-review for attending** — `/v1/attending/year/{year}` mirroring listening/running. Most-attended team/venue, total tickets bought, etc.
+- **NFL/NBA/WNBA box scores** — extend the MLB per-game-player enrichment to ESPN-covered leagues (the 13 non-MLB games currently lack player rows).
+- **Concert performer photos** — cross-link `lastfm_artist_id` to existing artist images in the listening domain so concert detail responses gain artist headshots.
+- **Concert event_data enrichment** — setlists, opener vs headliner discovery (setlist.fm beyond v1).
+- **ESPN photo backfill** — ~340 unmatched players (mostly relief pitchers/bench guys) still on silo-only.
+- **Team logos / venue photos** — TheSportsDB free, Google Places photo API or manual.
+- **Portfolio site Mariners 2024 page** in `pat-portfolio` — fetches MLB Stats API + `/v1/attending/seasons/mlb/2024` + renders the grid.

--- a/docs/projects/attending-domain/TRACKER.md
+++ b/docs/projects/attending-domain/TRACKER.md
@@ -416,13 +416,49 @@ curl https://api.rewind.rest/v1/health/sync \
 
 Look for `attending: { last_sync: <recent>, status: completed }`.
 
-## Phase 10+ — Follow-up projects (NOT in this project)
+## Phase 10: MCP tools + season-grid card UI — DONE (#55)
+
+Five tools registered, manifest snapshot bumped 40 → 45, MDX docs added.
+
+- [x] **10.1** `mcp-server/src/tools/attending.ts` — `get_attended_events`, `get_attended_season` (with `_meta.ui.resourceUri`), `get_attended_event`, `get_attended_player`, `get_attending_stats`. Text fallback uses `summarizeAppearance()` for batting/pitching lines.
+- [x] **10.2** UI bundle: `mcp-server/web/attended-season.{html,tsx}` + `components/SeasonGrid.tsx` + `components/SeasonGameCard.tsx`. `useApp` + `app.ontoolresult` binding; `app.openLink` for outbound. CSS variables for host theming. Built via vite-plugin-singlefile (455KB inlined HTML).
+- [x] **10.3** `registerUiResource('ui://rewind/attended-season.html', ...)` in `server.ts` with CSP allowing `cdn.rewind.rest`.
+- [x] **10.4** `mcp-server/scripts/check-docs.mjs` updated: tools added to `domains/attending.mdx`, `ui://rewind/attended-season.html` in `UNDOCUMENTED_ALLOWLIST`.
+- [x] **10.5** Tests: `server.test.ts` tool-count assertion bumped to 45; manifest snapshot regenerated via `npm run mcp:update`.
+
+## Phase 11: Activity feed integration — DONE (#57, #61, #62, #63, #64)
+
+Goal: every attended event appears in `/v1/feed`, `/v1/feed/on-this-day`, and `/v1/feed/domain/attending` alongside scrobbles/runs/watches/articles.
+
+**Validated end-to-end**: backfill ran cleanly to 263 attending rows in `activity_feed`; cross-domain feed surfaces attending entries dated correctly; on-this-day pulls them.
+
+- [x] **11.1** `src/services/attending/feed-items.ts` — `feedItemFromCanonical(eventId, canonical, venueName)` and `feedItemFromRow(row)` helpers. Verb is category-aware (`Saw <…>` for sports/music, `Attended <…>` for arts). `sourceId: 'event:{id}'`, `domain: 'attending'`, `eventType: 'event_attended' | 'event_missed'`.
+- [x] **11.2** `loadCanonicalEvent` (load.ts) inserts a feed row inline after writing source linkage. Wrapped in try/catch — feed-insert failures are non-fatal (mirrors lastfm/strava pattern).
+- [x] **11.3** `src/services/attending/backfill-feed.ts` — one-shot `backfillAttendingFeed(db, opts)` walks `attended_events`, joins venues, and feeds rows into `insertFeedItems`. Exposed via `POST /v1/admin/attending/backfill-feed`.
+- [x] **11.4** `insertFeedItems` rewritten to chunk both the dedupe `IN (...)` SELECT (CHUNK=80) and the multi-row INSERT VALUES (CHUNK=8 × 11 cols = 88 params) under D1's ~100-param effective cap. Also dropped the param-heavy pre-count in `backfill-feed` in favor of `count(*)` before/after.
+- [x] **11.5** Domain enum on `/v1/feed/domain/{domain}` Zod schema includes `'attending'`; OpenAPI snapshot regenerated.
+
+## Phase 12: Per-game player stats + photos (MLB) — DONE (#51–#54)
+
+Goal: each MLB attended event has per-player batting/pitching/fielding lines + headshots queryable via `get_attended_player` and rendered inline in the season-grid card.
+
+- [x] **12.1** `attended_event_players` writes from MLB Stats `boxscore.teams.{home,away}.players`. Captures batting line, pitching line, fielding line, decision (W/L/SV), batting order.
+- [x] **12.2** Player photos: silo (transparent PNG) from `img.mlbstatic.com/.../headshot/silo/current/{id}.png` for every player; ESPN full headshot from `a.espncdn.com/combiner/i?img=/i/headshots/mlb/players/full/{id}.png` cross-referenced from ESPN summary.
+- [x] **12.3** Cross-ref scoping (#53, #54): ESPN summary players intersected with the MLB boxscore roster for the same game; first-name-required match dedupes shared last names like Suárez.
+- [x] **12.4** PT/UTC date drift handled (#52): ESPN scoreboard stamps games at UTC midnight which is the next day in venue-local; matcher accepts date or date+1.
+- [x] **12.5** `images` row promotion fix (`cc6c5b2`): placeholder `image_version` advances 0 → 1 once the real image lands so CDN cache busts properly.
+
+**Result**: 839 unique players, 1,977 game appearances, 100% silo coverage, 60% full ESPN coverage.
+
+## Phase 13+ — Follow-up projects (NOT in this project, tracked in GitHub issues)
 
 Each gets its own `docs/projects/<name>/` doc when started:
 
-- [ ] **MCP tools for attending** — `get_attended_events`, `get_attended_season`, `get_attending_stats`, etc. Mechanical port from existing tool patterns.
-- [ ] **Activity feed integration** — surface attended events alongside scrobbles/runs/watches in `/v1/feed`.
-- [ ] **Image pipeline for attending** — team logos (TheSportsDB), venue photos (Google Places photo API), performer photos (already covered by `lastfm_artist_id` link).
-- [ ] **Portfolio site Mariners 2024 page** in `pat-portfolio` — fetches MLB Stats API + `/v1/attending/seasons/mlb/2024`. Generalize to other team/year combos.
+- [ ] **Year-in-review for attending** — `/v1/attending/year/{year}` mirroring listening/running.
+- [ ] **NFL/NBA/WNBA box scores** — extend MLB enrichment to ESPN-covered leagues for the 13 non-MLB games.
+- [ ] **Concert performer photos** — cross-link `lastfm_artist_id` to image so concert detail responses gain artist headshots.
+- [ ] **Setlists for concerts** — setlist.fm beyond v1 (opener vs headliner discovery).
+- [ ] **ESPN photo backfill** — ~340 unmatched players (mostly relief pitchers).
+- [ ] **Team logos / venue photos** — TheSportsDB + Google Places.
+- [ ] **Portfolio site Mariners 2024 page** in `pat-portfolio`.
 - [ ] **Portfolio UW 2008 season page** — same pattern, different league.
-- [ ] **Year-in-review for attending** — most-attended team/venue, total tickets bought, total spent.

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -1018,6 +1018,88 @@
           }
         }
       },
+      "AttendingEnrichEspnIdsBySearchResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          },
+          "scanned": {
+            "type": "integer"
+          },
+          "resolved_unique": {
+            "type": "integer"
+          },
+          "resolved_disambiguated": {
+            "type": "integer"
+          },
+          "multi_unresolved": {
+            "type": "integer"
+          },
+          "zero_match": {
+            "type": "integer"
+          },
+          "collision_skipped": {
+            "type": "integer"
+          },
+          "errors": {
+            "type": "integer"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "player_id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "player_id",
+                "name",
+                "reason"
+              ]
+            }
+          }
+        },
+        "required": [
+          "status",
+          "scanned",
+          "resolved_unique",
+          "resolved_disambiguated",
+          "multi_unresolved",
+          "zero_match",
+          "collision_skipped",
+          "errors",
+          "failures"
+        ]
+      },
+      "AttendingEnrichEspnIdsBySearchBody": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 500
+          },
+          "throttle_ms": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 2000,
+            "default": 50
+          }
+        }
+      },
       "AttendingBackfillFeedResponse": {
         "type": "object",
         "properties": {
@@ -21791,6 +21873,59 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttendingEnrichEspnIdsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/attending/enrich-espn-ids-by-search": {
+      "post": {
+        "operationId": "adminAttendingEnrichEspnIdsBySearch",
+        "x-hidden": true,
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Resolve ESPN player IDs via name search",
+        "description": "For every players row missing espn_id, hits ESPN site search and disambiguates by position class when a name returns multiple MLB hits. Complements enrich-espn-ids (game-summary scoped) by catching relief pitchers and bench players who do not appear in ESPN summary.athletes lists.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendingEnrichEspnIdsBySearchBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ESPN ID search resolution completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendingEnrichEspnIdsBySearchResponse"
                 }
               }
             }

--- a/src/routes/admin-attending.ts
+++ b/src/routes/admin-attending.ts
@@ -808,6 +808,83 @@ adminAttending.openapi(enrichEspnIdsRoute, async (c) => {
   }
 });
 
+// ─── POST /v1/admin/attending/enrich-espn-ids-by-search ─────────────
+
+const EnrichEspnIdsBySearchBody = z
+  .object({
+    limit: z.number().int().min(1).max(500).optional().default(500),
+    throttle_ms: z.number().int().min(0).max(2000).optional().default(50),
+  })
+  .openapi('AttendingEnrichEspnIdsBySearchBody');
+
+const EnrichEspnIdsBySearchResponse = z
+  .object({
+    status: z.literal('completed'),
+    scanned: z.number().int(),
+    resolved_unique: z.number().int(),
+    resolved_disambiguated: z.number().int(),
+    multi_unresolved: z.number().int(),
+    zero_match: z.number().int(),
+    collision_skipped: z.number().int(),
+    errors: z.number().int(),
+    failures: z.array(
+      z.object({
+        player_id: z.number().int(),
+        name: z.string(),
+        reason: z.string(),
+      })
+    ),
+  })
+  .openapi('AttendingEnrichEspnIdsBySearchResponse');
+
+const enrichEspnIdsBySearchRoute = createRoute({
+  method: 'post',
+  path: '/admin/attending/enrich-espn-ids-by-search',
+  operationId: 'adminAttendingEnrichEspnIdsBySearch',
+  'x-hidden': true,
+  tags: ['Admin'],
+  summary: 'Resolve ESPN player IDs via name search',
+  description:
+    'For every players row missing espn_id, hits ESPN site search and disambiguates by position class when a name returns multiple MLB hits. Complements enrich-espn-ids (game-summary scoped) by catching relief pitchers and bench players who do not appear in ESPN summary.athletes lists.',
+  request: {
+    body: {
+      content: { 'application/json': { schema: EnrichEspnIdsBySearchBody } },
+      required: false,
+    },
+  },
+  responses: {
+    200: {
+      description: 'ESPN ID search resolution completed',
+      content: {
+        'application/json': { schema: EnrichEspnIdsBySearchResponse },
+      },
+    },
+    ...errorResponses(401, 500),
+  },
+});
+
+adminAttending.openapi(enrichEspnIdsBySearchRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  type Opts = { limit?: number; throttle_ms?: number };
+  const body: Opts = await c.req.json<Opts>().catch(() => ({}) as Opts);
+
+  try {
+    const { enrichEspnIdsBySearch } =
+      await import('../services/attending/enrich-espn-ids-by-search.js');
+    const result = await enrichEspnIdsBySearch(db, {
+      limit: body.limit ?? 500,
+      throttleMs: body.throttle_ms ?? 50,
+    });
+    return c.json({ status: 'completed' as const, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(
+      `[ERROR] POST /admin/attending/enrich-espn-ids-by-search: ${message}`
+    );
+    return c.json({ error: message, status: 500 }, 500) as any;
+  }
+});
+
 // ─── POST /v1/admin/attending/backfill-feed ─────────────────────────
 
 const BackfillFeedBody = z

--- a/src/services/attending/enrich-espn-ids-by-search.test.ts
+++ b/src/services/attending/enrich-espn-ids-by-search.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { positionClass } from './enrich-espn-ids-by-search.js';
+
+describe('positionClass', () => {
+  it.each([
+    ['P', 'pitcher'],
+    ['SP', 'pitcher'],
+    ['RP', 'pitcher'],
+    ['CL', 'pitcher'],
+    ['CP', 'pitcher'],
+    ['LR', 'pitcher'],
+    ['MR', 'pitcher'],
+    ['SU', 'pitcher'],
+    ['C', 'catcher'],
+    ['1B', 'infield'],
+    ['2B', 'infield'],
+    ['3B', 'infield'],
+    ['SS', 'infield'],
+    ['IF', 'infield'],
+    ['LF', 'outfield'],
+    ['CF', 'outfield'],
+    ['RF', 'outfield'],
+    ['OF', 'outfield'],
+    ['DH', 'dh'],
+    [null, 'unknown'],
+    [undefined, 'unknown'],
+    ['', 'unknown'],
+    ['UTIL', 'unknown'],
+    // case insensitivity
+    ['p', 'pitcher'],
+    ['1b', 'infield'],
+  ] as const)('classifies %s -> %s', (abbr, expected) => {
+    expect(positionClass(abbr)).toBe(expected);
+  });
+});

--- a/src/services/attending/enrich-espn-ids-by-search.ts
+++ b/src/services/attending/enrich-espn-ids-by-search.ts
@@ -1,0 +1,292 @@
+// Search-based ESPN player-id resolver. Complement to
+// `enrich-espn-ids.ts` (which game-scopes via box scores) — that path
+// only catches players who appear in ESPN game summaries, which leaves
+// out relief pitchers and bench players who are in MLB Stats boxscores
+// but not in ESPN's summary.athletes lists.
+//
+// This resolver walks every `players` row missing an `espn_id` and hits
+// ESPN's site search (`apis/search/v2`) by normalized name, filtered to
+// MLB results. When the search returns multiple MLB hits for the same
+// name (e.g. two Chris Youngs, two John McDonalds), we disambiguate by
+// fetching each candidate's `common/v3/.../athletes/{id}` profile and
+// matching position class against our `primary_position`.
+//
+// Probe results (2026-04-26): of 340 unmatched MLB players,
+//   - 310 have a single MLB search hit
+//   -  25 have multiple MLB hits (position-class disambiguation works)
+//   -   5 have zero hits (name-format quirks like "C.J. Wilson")
+// Realistic resolution rate: ~97%.
+
+import { and, eq, isNull } from 'drizzle-orm';
+import type { Database } from '../../db/client.js';
+import { players } from '../../db/schema/attending.js';
+
+const SEARCH_URL = 'https://site.web.api.espn.com/apis/search/v2';
+const PROFILE_URL =
+  'https://site.web.api.espn.com/apis/common/v3/sports/baseball/mlb/athletes';
+
+export interface EnrichEspnIdsBySearchOptions {
+  // Limit how many players to scan in one call. Each scan is ~1 search
+  // request, plus 1 profile request per multi-hit candidate.
+  limit?: number;
+  // Throttle between ESPN requests (ms). ESPN is unmetered but we don't
+  // want to hammer it.
+  throttleMs?: number;
+}
+
+export interface EnrichEspnIdsBySearchResult {
+  scanned: number;
+  resolved_unique: number;
+  resolved_disambiguated: number;
+  multi_unresolved: number;
+  zero_match: number;
+  collision_skipped: number;
+  errors: number;
+  failures: Array<{ player_id: number; name: string; reason: string }>;
+}
+
+interface EspnSearchHit {
+  espn_id: string;
+  display_name: string;
+  subtitle: string;
+}
+
+interface EspnProfileSummary {
+  id: string;
+  display_name: string;
+  jersey: string | null;
+  position_abbr: string | null;
+  team_name: string | null;
+}
+
+export async function enrichEspnIdsBySearch(
+  db: Database,
+  opts: EnrichEspnIdsBySearchOptions = {}
+): Promise<EnrichEspnIdsBySearchResult> {
+  const { limit = 500, throttleMs = 50 } = opts;
+
+  const result: EnrichEspnIdsBySearchResult = {
+    scanned: 0,
+    resolved_unique: 0,
+    resolved_disambiguated: 0,
+    multi_unresolved: 0,
+    zero_match: 0,
+    collision_skipped: 0,
+    errors: 0,
+    failures: [],
+  };
+
+  const candidates = await db
+    .select({
+      id: players.id,
+      first_name: players.firstName,
+      last_name: players.lastName,
+      primary_position: players.primaryPosition,
+      primary_number: players.primaryNumber,
+    })
+    .from(players)
+    .where(and(eq(players.league, 'mlb'), isNull(players.espnId)))
+    .limit(limit);
+
+  for (const p of candidates) {
+    result.scanned++;
+    if (!p.first_name || !p.last_name) {
+      result.failures.push({
+        player_id: p.id,
+        name: `${p.first_name ?? ''} ${p.last_name ?? ''}`.trim(),
+        reason: 'missing first or last name',
+      });
+      continue;
+    }
+
+    const queryName = `${normalize(p.first_name)} ${normalize(p.last_name)}`;
+    let hits: EspnSearchHit[];
+    try {
+      hits = await searchEspn(queryName);
+    } catch (err) {
+      result.errors++;
+      result.failures.push({
+        player_id: p.id,
+        name: queryName,
+        reason: `search: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      await sleep(throttleMs);
+      continue;
+    }
+
+    let chosen: { espnId: string; via: 'unique' | 'disambiguated' } | null =
+      null;
+
+    if (hits.length === 0) {
+      result.zero_match++;
+    } else if (hits.length === 1) {
+      chosen = { espnId: hits[0].espn_id, via: 'unique' };
+    } else {
+      // Multi-hit: fetch each candidate's profile and disambiguate by
+      // position class. We also check jersey as a backup tiebreaker.
+      const profiles: EspnProfileSummary[] = [];
+      for (const h of hits) {
+        try {
+          const prof = await fetchProfile(h.espn_id);
+          if (prof) profiles.push(prof);
+        } catch {
+          // Skip individual profile errors — leave the candidate out.
+        }
+        await sleep(throttleMs);
+      }
+      const ourClass = positionClass(p.primary_position);
+      const positionMatches = profiles.filter(
+        (prof) => positionClass(prof.position_abbr) === ourClass
+      );
+
+      if (positionMatches.length === 1) {
+        chosen = { espnId: positionMatches[0].id, via: 'disambiguated' };
+      } else if (positionMatches.length > 1 && p.primary_number) {
+        // Fall back to jersey number when position class can't break
+        // the tie (extremely rare — same name, same position).
+        const jerseyMatch = positionMatches.find(
+          (prof) => prof.jersey === p.primary_number
+        );
+        if (jerseyMatch) {
+          chosen = { espnId: jerseyMatch.id, via: 'disambiguated' };
+        }
+      }
+
+      if (!chosen) {
+        result.multi_unresolved++;
+        result.failures.push({
+          player_id: p.id,
+          name: queryName,
+          reason: `${hits.length} MLB hits, position-class=${ourClass}, ${positionMatches.length} pos-matches`,
+        });
+      }
+    }
+
+    if (chosen) {
+      // Belt-and-suspenders: don't overwrite an espn_id already taken
+      // by a different player. The unique (league, espn_id) index would
+      // throw, but we'd rather count it than crash the loop.
+      const taken = await db
+        .select({ id: players.id })
+        .from(players)
+        .where(
+          and(eq(players.league, 'mlb'), eq(players.espnId, chosen.espnId))
+        )
+        .limit(1);
+      if (taken.length > 0 && taken[0].id !== p.id) {
+        result.collision_skipped++;
+        result.failures.push({
+          player_id: p.id,
+          name: queryName,
+          reason: `espn_id ${chosen.espnId} already on player ${taken[0].id}`,
+        });
+      } else {
+        await db
+          .update(players)
+          .set({ espnId: chosen.espnId, updatedAt: new Date().toISOString() })
+          .where(eq(players.id, p.id));
+        if (chosen.via === 'unique') result.resolved_unique++;
+        else result.resolved_disambiguated++;
+      }
+    }
+
+    await sleep(throttleMs);
+  }
+
+  return result;
+}
+
+async function searchEspn(name: string): Promise<EspnSearchHit[]> {
+  const url = `${SEARCH_URL}?region=us&lang=en&query=${encodeURIComponent(name)}&limit=10`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'rewind/1.0' } });
+  if (!res.ok) throw new Error(`search ${res.status}`);
+  const body = (await res.json()) as {
+    results?: Array<{
+      type?: string;
+      contents?: Array<{
+        defaultLeagueSlug?: string;
+        displayName?: string;
+        subtitle?: string;
+        link?: { web?: string };
+      }>;
+    }>;
+  };
+  const hits: EspnSearchHit[] = [];
+  for (const r of body.results ?? []) {
+    if (r.type !== 'player') continue;
+    for (const c of r.contents ?? []) {
+      if (c.defaultLeagueSlug !== 'mlb') continue;
+      const link = c.link?.web ?? '';
+      const idMatch = link.match(/\/id\/(\d+)/);
+      if (!idMatch) continue;
+      hits.push({
+        espn_id: idMatch[1],
+        display_name: c.displayName ?? '',
+        subtitle: c.subtitle ?? '',
+      });
+    }
+  }
+  return hits;
+}
+
+async function fetchProfile(
+  espnId: string
+): Promise<EspnProfileSummary | null> {
+  const url = `${PROFILE_URL}/${espnId}`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'rewind/1.0' } });
+  if (!res.ok) return null;
+  const body = (await res.json()) as {
+    athlete?: {
+      id?: string;
+      displayName?: string;
+      jersey?: string;
+      position?: { abbreviation?: string };
+      team?: { displayName?: string };
+    };
+  };
+  const a = body.athlete;
+  if (!a?.id) return null;
+  return {
+    id: a.id,
+    display_name: a.displayName ?? '',
+    jersey: a.jersey ?? null,
+    position_abbr: a.position?.abbreviation ?? null,
+    team_name: a.team?.displayName ?? null,
+  };
+}
+
+/**
+ * Coarse position classes for MLB-Stats / ESPN cross-matching.
+ *
+ * MLB Stats uses generic codes like "P" for any pitcher, while ESPN
+ * splits SP/RP/CL/etc. We collapse to a small set so a "P" in our DB
+ * matches any pitching variant on ESPN's side.
+ */
+export function positionClass(
+  abbr: string | null | undefined
+): 'pitcher' | 'catcher' | 'infield' | 'outfield' | 'dh' | 'unknown' {
+  if (!abbr) return 'unknown';
+  const a = abbr.toUpperCase();
+  if (a === 'P' || a === 'SP' || a === 'RP' || a === 'CL' || a === 'CP')
+    return 'pitcher';
+  if (a === 'LR' || a === 'MR' || a === 'SU') return 'pitcher';
+  if (a === 'C') return 'catcher';
+  if (a === '1B' || a === '2B' || a === '3B' || a === 'SS' || a === 'IF')
+    return 'infield';
+  if (a === 'LF' || a === 'CF' || a === 'RF' || a === 'OF') return 'outfield';
+  if (a === 'DH') return 'dh';
+  return 'unknown';
+}
+
+function normalize(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[.]/g, '') // "C.J." → "CJ"
+    .trim()
+    .toLowerCase();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Adds a complementary ESPN player-id resolver that catches the ~340 MLB players the existing game-summary resolver misses — relief pitchers, bench guys, and anyone else who's in the MLB Stats boxscore but not in ESPN's `summary.athletes` lists. Fixes #70.

Strategy: hit ESPN's site search by normalized name, filter to MLB results, disambiguate multi-name collisions (Chris Young, John McDonald, Joe Smith) by fetching each candidate's profile and matching position class against `players.primary_position`.

Probe across all 340 unmatched players: 310 unique-hit, 25 multi-hit (disambiguable), 5 zero-hit (name format quirks like "C.J. Wilson"). Realistic resolution ~97% — should take MLB photo coverage from 60% (499/839) to ~99% (832/839).

Wired up as `POST /v1/admin/attending/enrich-espn-ids-by-search`. Run order: this resolver, then existing `enrich-player-photos` to fetch the ESPN headshot variant for newly-matched players.

## Test plan

- [x] 25 unit tests on `positionClass` mapping
- [x] Full test suite: 891/891 pass
- [x] OpenAPI snapshot regenerated
- [ ] Run against prod — verify resolved counts roughly match probe predictions
- [ ] Run `enrich-player-photos` after — verify full-headshot count climbs from 499

🤖 Generated with [Claude Code](https://claude.com/claude-code)