### PR TITLE
feat(lib): extract D1 parameter chunking helpers (closes #71)

### DIFF
--- a/src/lib/d1-chunk.test.ts
+++ b/src/lib/d1-chunk.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  D1_PARAM_CAP,
+  chunkForSelectIn,
+  chunkForInsertValues,
+} from './d1-chunk.js';
+
+describe('D1_PARAM_CAP', () => {
+  it('is the empirically-proven 88', () => {
+    // Tied to the attending activity-feed backfill: 8 rows * 11 cols = 88.
+    // If this changes, audit existing call sites that hard-coded the value.
+    expect(D1_PARAM_CAP).toBe(88);
+  });
+});
+
+describe('chunkForSelectIn', () => {
+  it('yields nothing for an empty input', () => {
+    expect([...chunkForSelectIn([])]).toEqual([]);
+  });
+
+  it('yields a single chunk under the cap', () => {
+    const ids = Array.from({ length: 50 }, (_, i) => i);
+    const chunks = [...chunkForSelectIn(ids)];
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(50);
+  });
+
+  it('splits at exactly D1_PARAM_CAP', () => {
+    const ids = Array.from({ length: D1_PARAM_CAP }, (_, i) => i);
+    const chunks = [...chunkForSelectIn(ids)];
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(D1_PARAM_CAP);
+  });
+
+  it('splits over the cap', () => {
+    const ids = Array.from({ length: 200 }, (_, i) => i);
+    const chunks = [...chunkForSelectIn(ids)];
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toHaveLength(D1_PARAM_CAP);
+    expect(chunks[1]).toHaveLength(D1_PARAM_CAP);
+    expect(chunks[2]).toHaveLength(200 - 2 * D1_PARAM_CAP);
+  });
+
+  it('reserves params for additional predicates', () => {
+    const ids = Array.from({ length: 200 }, (_, i) => i);
+    const chunks = [...chunkForSelectIn(ids, 8)];
+    const expectedSize = D1_PARAM_CAP - 8; // 80
+    expect(chunks[0]).toHaveLength(expectedSize);
+    expect(chunks).toHaveLength(Math.ceil(200 / expectedSize));
+  });
+
+  it('preserves all values across chunks (no drops, no dupes)', () => {
+    const ids = Array.from({ length: 300 }, (_, i) => i);
+    const flat = [...chunkForSelectIn(ids, 5)].flat();
+    expect(flat).toEqual(ids);
+  });
+
+  it('rejects negative reservedParams', () => {
+    expect(() => [...chunkForSelectIn([1], -1)]).toThrow(/reservedParams/);
+  });
+
+  it('rejects reservedParams >= cap', () => {
+    expect(() => [...chunkForSelectIn([1], D1_PARAM_CAP)]).toThrow(
+      /reservedParams/
+    );
+  });
+});
+
+describe('chunkForInsertValues', () => {
+  it('yields nothing for an empty input', () => {
+    expect([...chunkForInsertValues([], 5)]).toEqual([]);
+  });
+
+  it('chunks at floor(cap / columnsPerRow)', () => {
+    // 11 cols × 8 rows = 88 params (the activity-feed shape).
+    const rows = Array.from({ length: 25 }, (_, i) => ({ i }));
+    const chunks = [...chunkForInsertValues(rows, 11)];
+    expect(chunks[0]).toHaveLength(8);
+    expect(chunks[1]).toHaveLength(8);
+    expect(chunks[2]).toHaveLength(8);
+    expect(chunks[3]).toHaveLength(1);
+  });
+
+  it('handles a single wide row', () => {
+    const rows = [{ a: 1 }];
+    const chunks = [...chunkForInsertValues(rows, 50)];
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual(rows);
+  });
+
+  it('preserves all rows in order across chunks', () => {
+    const rows = Array.from({ length: 100 }, (_, i) => ({ i }));
+    const flat = [...chunkForInsertValues(rows, 7)].flat();
+    expect(flat).toEqual(rows);
+  });
+
+  it('rejects zero or negative columnsPerRow', () => {
+    expect(() => [...chunkForInsertValues([{}], 0)]).toThrow(
+      /columnsPerRow must be positive/
+    );
+    expect(() => [...chunkForInsertValues([{}], -1)]).toThrow(
+      /columnsPerRow must be positive/
+    );
+  });
+
+  it('rejects columnsPerRow over the cap', () => {
+    expect(() => [...chunkForInsertValues([{}], D1_PARAM_CAP + 1)]).toThrow(
+      /exceeds D1_PARAM_CAP/
+    );
+  });
+});

--- a/src/lib/d1-chunk.ts
+++ b/src/lib/d1-chunk.ts
@@ -1,0 +1,82 @@
+// D1 bound-parameter chunking helpers.
+//
+// Cloudflare D1's effective per-query parameter cap is ~100 in practice,
+// not the 256 documented in the platform notes. Both `IN (?, ?, ...)`
+// SELECTs and `INSERT INTO t (...) VALUES (?, ?), (?, ?)` multi-row
+// writes can blow past this with batches of 200+ rows — we hit it twice
+// during the attending activity-feed backfill before settling on
+// SELECT_CHUNK=80 + INSERT_CHUNK=8 (8 rows × 11 cols = 88 params).
+//
+// This module captures that empirically-derived cap in one place so
+// future bulk admin endpoints don't rediscover the wall mid-prod-backfill.
+//
+// Usage:
+//   for (const ids of chunkForSelectIn(sourceIds)) {
+//     const rows = await db.select(...).where(inArray(t.sourceId, ids));
+//   }
+//
+//   for (const rows of chunkForInsertValues(items, 11)) {
+//     await db.insert(t).values(rows);
+//   }
+
+/**
+ * Empirically-derived effective parameter cap for D1. Documented as 256
+ * but the planner trips well before that for large IN-lists; 88 is
+ * comfortably under the wall and proven against prod.
+ *
+ * Set deliberately on the conservative side so callers never have to
+ * tune it. If you find yourself wanting to push past this, write tests
+ * that reproduce the failure mode first — the docs lie.
+ */
+export const D1_PARAM_CAP = 88;
+
+/**
+ * Chunk an array of values for use in a `WHERE col IN (?, ?, ...)`
+ * predicate. Each chunk has at most `D1_PARAM_CAP - reservedParams`
+ * entries so callers can leave room for other bound parameters in the
+ * same query (e.g. an additional `WHERE domain = ?` predicate).
+ *
+ * Yields nothing for an empty input — caller is responsible for the
+ * "skip the query entirely" short-circuit when that matters.
+ */
+export function* chunkForSelectIn<T>(
+  values: readonly T[],
+  reservedParams = 0
+): Generator<T[]> {
+  if (reservedParams < 0 || reservedParams >= D1_PARAM_CAP) {
+    throw new Error(
+      `reservedParams must be 0..${D1_PARAM_CAP - 1}, got ${reservedParams}`
+    );
+  }
+  const size = D1_PARAM_CAP - reservedParams;
+  for (let i = 0; i < values.length; i += size) {
+    yield values.slice(i, i + size);
+  }
+}
+
+/**
+ * Chunk an array of row objects for a multi-row INSERT VALUES write.
+ * Each chunk has at most `floor(D1_PARAM_CAP / columnsPerRow)` rows so
+ * the resulting bound parameters fit under the cap.
+ *
+ * Throws if `columnsPerRow` exceeds the cap — single-row INSERTs of
+ * that width can't be batched at all and the caller needs to either
+ * narrow the column set or insert one row per statement.
+ */
+export function* chunkForInsertValues<T>(
+  rows: readonly T[],
+  columnsPerRow: number
+): Generator<T[]> {
+  if (columnsPerRow <= 0) {
+    throw new Error(`columnsPerRow must be positive, got ${columnsPerRow}`);
+  }
+  if (columnsPerRow > D1_PARAM_CAP) {
+    throw new Error(
+      `columnsPerRow=${columnsPerRow} exceeds D1_PARAM_CAP=${D1_PARAM_CAP}; insert one row at a time instead`
+    );
+  }
+  const size = Math.floor(D1_PARAM_CAP / columnsPerRow);
+  for (let i = 0; i < rows.length; i += size) {
+    yield rows.slice(i, i + size);
+  }
+}

--- a/src/routes/feed.ts
+++ b/src/routes/feed.ts
@@ -3,6 +3,7 @@ import { desc, eq, and, lt, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { activityFeed } from '../db/schema/system.js';
 import { setCache } from '../lib/cache.js';
+import { chunkForInsertValues, chunkForSelectIn } from '../lib/d1-chunk.js';
 import { DateFilterQuery, buildDateCondition } from '../lib/date-filters.js';
 import { requireAuth } from '../lib/auth.js';
 import { badRequest } from '../lib/errors.js';
@@ -447,13 +448,11 @@ export async function insertFeedItem(
 /**
  * Batch insert activity feed items. Called by domain sync services.
  *
- * D1 caps bound parameters per query (~256 in practice). Both the
- * dedupe SELECT (`IN (?, ?, ...)`) and the multi-row INSERT
- * (`VALUES (?, ?, ?, ...), (...)`) can blow past that with large
- * batches — sport-domain backfills routinely hand us 200+ items.
- * Chunk both operations: 200 source_ids per dedupe lookup, 20 rows
- * per INSERT (20 × 11 columns ≈ 220 params, comfortably under the
- * cap with headroom).
+ * D1's effective per-query parameter cap is ~100 (not the documented
+ * 256). Both the dedupe SELECT and the multi-row INSERT can blow past
+ * that with batches of 200+ items, so we route both through the
+ * `chunkForSelectIn` / `chunkForInsertValues` helpers in `lib/d1-chunk`
+ * which encode the empirically-derived cap in one place.
  */
 export async function insertFeedItems(
   db: ReturnType<typeof drizzle>,
@@ -471,19 +470,14 @@ export async function insertFeedItems(
 ) {
   if (items.length === 0) return;
 
-  // D1's effective per-query param cap is around 100 in practice;
-  // 200-source-id IN-lists still tripped the planner. Stay well below.
-  const SELECT_CHUNK = 80; // dedupe IN-list cap (+ 1 for domain)
-  const INSERT_CHUNK = 8; // INSERT VALUES row cap (8 × 11 cols = 88 params)
-
   const domains = [...new Set(items.map((i) => i.domain))];
 
   // Chunked dedupe lookup: walk source_ids in batches and accumulate
-  // the keys already present in activity_feed.
+  // the keys already present in activity_feed. Reserve params for the
+  // companion `domain IN (...)` predicate so the combined query fits.
   const existingSet = new Set<string>();
   const sourceIds = items.map((i) => i.sourceId);
-  for (let i = 0; i < sourceIds.length; i += SELECT_CHUNK) {
-    const chunk = sourceIds.slice(i, i + SELECT_CHUNK);
+  for (const chunk of chunkForSelectIn(sourceIds, domains.length)) {
     const existing = await db
       .select({
         sourceId: activityFeed.sourceId,
@@ -527,8 +521,9 @@ export async function insertFeedItems(
     createdAt: now,
   }));
 
-  for (let i = 0; i < rows.length; i += INSERT_CHUNK) {
-    await db.insert(activityFeed).values(rows.slice(i, i + INSERT_CHUNK));
+  // 10 columns per row in the activity_feed insert shape above.
+  for (const batch of chunkForInsertValues(rows, 10)) {
+    await db.insert(activityFeed).values(batch);
   }
 }
 

--- a/src/services/strava/sync.ts
+++ b/src/services/strava/sync.ts
@@ -12,6 +12,7 @@ import {
 import type { Env } from '../../types/env.js';
 import { StravaClient } from './client.js';
 import { afterSync } from '../../lib/after-sync.js';
+import { chunkForInsertValues } from '../../lib/d1-chunk.js';
 import type { FeedItem, SearchItem } from '../../lib/after-sync.js';
 import {
   transformActivity,
@@ -126,8 +127,10 @@ export async function syncRunning(env: Env, db: Database): Promise<number> {
             detailedActivity.id,
             detailedActivity.splits_standard
           );
-          if (splitValues.length > 0) {
-            await db.insert(stravaSplits).values(splitValues);
+          // 16 cols × up to 26 splits (marathon) can exceed D1's
+          // ~88-param effective cap; chunk to stay under it.
+          for (const batch of chunkForInsertValues(splitValues, 16)) {
+            await db.insert(stravaSplits).values(batch);
           }
         }
 
@@ -585,8 +588,8 @@ export async function syncSingleActivity(
       .where(eq(stravaSplits.activityStravaId, stravaId));
 
     const splitValues = transformSplits(stravaId, activity.splits_standard);
-    if (splitValues.length > 0) {
-      await db.insert(stravaSplits).values(splitValues);
+    for (const batch of chunkForInsertValues(splitValues, 16)) {
+      await db.insert(stravaSplits).values(batch);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #71. Pulls the per-statement parameter chunking from `insertFeedItems` into `src/lib/d1-chunk.ts` so future bulk admin endpoints don't rediscover D1's ~100-param effective cap mid-prod-backfill.

- New module exports `D1_PARAM_CAP = 88`, `chunkForSelectIn(values, reservedParams)`, and `chunkForInsertValues(rows, columnsPerRow)`. Generators, throw on misuse.
- Migrated `insertFeedItems` (the original incident site) to the helpers.
- Migrated `stravaSplits` inserts in `services/strava/sync.ts` — 16 cols × up to 26 marathon splits could exceed the cap on a long run; latent risk that hadn't fired yet.
- Surveyed other bulk insert sites (lastfm, plex, letterboxd, attending) — all are single-row writes inside per-item loops, already safe.

## Test plan

- [x] 15 unit tests on the chunking helpers
- [x] Full suite: 906/906 pass
- [x] `feed.test.ts` still green after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)