### PR TITLE
feat(attending): year-in-review endpoint + MCP tool (closes #66)

### DIFF
--- a/docs-mintlify/mcp-server.mdx
+++ b/docs-mintlify/mcp-server.mdx
@@ -156,6 +156,7 @@ Requires a [Rewind API key](/authentication). `REWIND_API_URL` defaults to `http
     | `get_attended_season`   | Sports season W/L + game list with notable performers; renders as an interactive grid in MCP Apps clients |
     | `get_attended_player`   | Player bio + photos + every attended event in which they appeared with stat lines                    |
     | `get_attending_stats`   | Aggregate counts of attended events by category, type, and year                                      |
+    | `get_attending_year_in_review` | Year-in-review summary: totals, monthly breakdown, top venues, top performers, and full event list |
   </Accordion>
 
   <Accordion title="Cross-Domain">

--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -19811,6 +19811,240 @@
         }
       }
     },
+    "/v1/attending/year/{year}": {
+      "get": {
+        "operationId": "getAttendingYearInReview",
+        "tags": [
+          "Attending"
+        ],
+        "summary": "Year in review",
+        "description": "Returns a year-in-review summary for attended events: totals, monthly breakdown, top venues, top concert performers, and the full event list. 404 when no attended events exist for the year.",
+        "parameters": [
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "example": 2024
+            },
+            "required": true,
+            "name": "year",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Year in review",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "year": {
+                      "type": "number"
+                    },
+                    "total_events": {
+                      "type": "number"
+                    },
+                    "total_spent_cents": {
+                      "type": "number"
+                    },
+                    "by_category": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "category": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "category",
+                          "count"
+                        ]
+                      }
+                    },
+                    "by_event_type": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "event_type": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "event_type",
+                          "count"
+                        ]
+                      }
+                    },
+                    "monthly": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "month": {
+                            "type": "string",
+                            "example": "2024-08"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "month",
+                          "count"
+                        ]
+                      }
+                    },
+                    "top_venues": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "venue_id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "city": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "venue_id",
+                          "name",
+                          "city",
+                          "count"
+                        ]
+                      }
+                    },
+                    "top_performers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "performer_id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "performer_id",
+                          "name",
+                          "count"
+                        ]
+                      }
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "event_date": {
+                            "type": "string"
+                          },
+                          "event_type": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "venue_name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "event_date",
+                          "event_type",
+                          "title",
+                          "subtitle",
+                          "venue_name"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "year",
+                    "total_events",
+                    "total_spent_cents",
+                    "by_category",
+                    "by_event_type",
+                    "monthly",
+                    "top_venues",
+                    "top_performers",
+                    "events"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/feed": {
       "get": {
         "operationId": "getFeed",

--- a/mcp-server/mcp-manifest.snapshot.json
+++ b/mcp-server/mcp-manifest.snapshot.json
@@ -313,6 +313,24 @@
       }
     },
     {
+      "name": "get_attending_year_in_review",
+      "description": "Year-in-review summary for attended events: totals, monthly breakdown, top venues, top concert performers, and the full event list. Use this when the user asks \"what shows did I see in 2024\" or \"best year for games\".",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "description": "Calendar year, e.g. 2024."
+          }
+        },
+        "required": [
+          "year"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    },
+    {
       "name": "get_collecting_stats",
       "description": "Get overall collection statistics including total items, format breakdown (vinyl, CD, cassette), unique artists, genre data, and year range. Supports date filtering.",
       "inputSchema": {

--- a/mcp-server/src/__tests__/server.test.ts
+++ b/mcp-server/src/__tests__/server.test.ts
@@ -775,7 +775,7 @@ describe('MCP Server', () => {
       // an accompanying docs update. See manifest-snapshot.test.ts for
       // the structural snapshot and scripts/check-docs.mjs for the
       // MDX cross-check.
-      expect(tools.length).toBe(45);
+      expect(tools.length).toBe(46);
 
       const names = tools.map((t) => t.name);
       expect(names).toContain('get_health');

--- a/mcp-server/src/tools/attending.ts
+++ b/mcp-server/src/tools/attending.ts
@@ -106,6 +106,34 @@ type AttendingStats = {
   by_year: Array<{ year: string; count: number }>;
 };
 
+type AttendingYearInReview = {
+  year: number;
+  total_events: number;
+  total_spent_cents: number;
+  by_category: Array<{ category: string; count: number }>;
+  by_event_type: Array<{ event_type: string; count: number }>;
+  monthly: Array<{ month: string; count: number }>;
+  top_venues: Array<{
+    venue_id: number;
+    name: string;
+    city: string | null;
+    count: number;
+  }>;
+  top_performers: Array<{
+    performer_id: number;
+    name: string;
+    count: number;
+  }>;
+  events: Array<{
+    id: number;
+    event_date: string;
+    event_type: string;
+    title: string;
+    subtitle: string | null;
+    venue_name: string | null;
+  }>;
+};
+
 // ─── Tool registration ───────────────────────────────────────────────
 
 export function registerAttendingTools(
@@ -412,6 +440,58 @@ export function registerAttendingTools(
             const stat = summarizeAppearance(a);
             const decision = a.decision ? ` (${a.decision})` : '';
             lines.push(`  ${a.player.full_name}${decision} -- ${stat}`);
+          }
+        }
+
+        return {
+          content: [text(lines.join('\n'))],
+          structuredContent: data,
+        };
+      })
+  );
+
+  // get_attending_year_in_review ────────────────────────────────────
+  server.tool(
+    'get_attending_year_in_review',
+    'Year-in-review summary for attended events: totals, monthly breakdown, top venues, top concert performers, and the full event list. Use this when the user asks "what shows did I see in 2024" or "best year for games".',
+    {
+      year: z.number().int().describe('Calendar year, e.g. 2024.'),
+    },
+    READ_ONLY_ANNOTATIONS,
+    async ({ year }) =>
+      withRichResponse(async () => {
+        const data = await client.get<AttendingYearInReview>(
+          `/attending/year/${year}`
+        );
+
+        const lines = [
+          `${data.year}: ${fmt(data.total_events)} attended events`,
+        ];
+        if (data.total_spent_cents > 0) {
+          lines.push(
+            `Total ticket spend: $${(data.total_spent_cents / 100).toFixed(2)}`
+          );
+        }
+
+        if (data.by_event_type.length) {
+          lines.push('', 'By event type:');
+          for (const r of data.by_event_type) {
+            lines.push(`  ${r.event_type}: ${fmt(r.count)}`);
+          }
+        }
+
+        if (data.top_venues.length) {
+          lines.push('', 'Top venues:');
+          for (const v of data.top_venues) {
+            const city = v.city ? ` (${v.city})` : '';
+            lines.push(`  ${v.name}${city}: ${fmt(v.count)}`);
+          }
+        }
+
+        if (data.top_performers.length) {
+          lines.push('', 'Top performers:');
+          for (const p of data.top_performers) {
+            lines.push(`  ${p.name}: ${fmt(p.count)}`);
           }
         }
 

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -19811,6 +19811,240 @@
         }
       }
     },
+    "/v1/attending/year/{year}": {
+      "get": {
+        "operationId": "getAttendingYearInReview",
+        "tags": [
+          "Attending"
+        ],
+        "summary": "Year in review",
+        "description": "Returns a year-in-review summary for attended events: totals, monthly breakdown, top venues, top concert performers, and the full event list. 404 when no attended events exist for the year.",
+        "parameters": [
+          {
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "example": 2024
+            },
+            "required": true,
+            "name": "year",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Year in review",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "year": {
+                      "type": "number"
+                    },
+                    "total_events": {
+                      "type": "number"
+                    },
+                    "total_spent_cents": {
+                      "type": "number"
+                    },
+                    "by_category": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "category": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "category",
+                          "count"
+                        ]
+                      }
+                    },
+                    "by_event_type": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "event_type": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "event_type",
+                          "count"
+                        ]
+                      }
+                    },
+                    "monthly": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "month": {
+                            "type": "string",
+                            "example": "2024-08"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "month",
+                          "count"
+                        ]
+                      }
+                    },
+                    "top_venues": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "venue_id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "city": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "venue_id",
+                          "name",
+                          "city",
+                          "count"
+                        ]
+                      }
+                    },
+                    "top_performers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "performer_id": {
+                            "type": "number"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "performer_id",
+                          "name",
+                          "count"
+                        ]
+                      }
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "event_date": {
+                            "type": "string"
+                          },
+                          "event_type": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "venue_name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "event_date",
+                          "event_type",
+                          "title",
+                          "subtitle",
+                          "venue_name"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "year",
+                    "total_events",
+                    "total_spent_cents",
+                    "by_category",
+                    "by_event_type",
+                    "monthly",
+                    "top_venues",
+                    "top_performers",
+                    "events"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/feed": {
       "get": {
         "operationId": "getFeed",

--- a/src/routes/attending-year.test.ts
+++ b/src/routes/attending-year.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/d1';
+import {
+  attendedEventPerformers,
+  attendedEvents,
+  attendedEventTickets,
+  performers,
+  venues,
+} from '../db/schema/attending.js';
+import { setupTestDb, createTestApiKey } from '../test-helpers.js';
+
+describe('GET /v1/attending/year/{year}', () => {
+  let token: string;
+
+  beforeAll(async () => {
+    await setupTestDb();
+    token = await createTestApiKey({ name: 'year-test', scope: 'read' });
+  });
+
+  beforeEach(async () => {
+    const db = drizzle(env.DB);
+    await db.delete(attendedEventTickets);
+    await db.delete(attendedEventPerformers);
+    await db.delete(attendedEvents);
+    await db.delete(performers);
+    await db.delete(venues);
+  });
+
+  it('returns 404 when no attended events for the year', async () => {
+    const res = await SELF.fetch('https://test/v1/attending/year/2024', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for an out-of-range year', async () => {
+    const res = await SELF.fetch('https://test/v1/attending/year/1990', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('aggregates attended events and ignores attended=0 + other years', async () => {
+    const db = drizzle(env.DB);
+    const [v1] = await db
+      .insert(venues)
+      .values({ name: 'T-Mobile Park', city: 'Seattle' })
+      .returning();
+    const [v2] = await db
+      .insert(venues)
+      .values({ name: 'Husky Stadium', city: 'Seattle' })
+      .returning();
+    const [p1] = await db
+      .insert(performers)
+      .values({ name: 'Phoebe Bridgers' })
+      .returning();
+
+    const now = new Date().toISOString();
+    // Three attended in 2024, two at T-Mobile and one at Husky.
+    const [e1] = await db
+      .insert(attendedEvents)
+      .values({
+        userId: 1,
+        category: 'sports',
+        eventType: 'mlb_game',
+        eventDate: '2024-06-15',
+        title: 'Mariners vs Yankees',
+        venueId: v1.id,
+        attended: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+    await db.insert(attendedEvents).values({
+      userId: 1,
+      category: 'sports',
+      eventType: 'mlb_game',
+      eventDate: '2024-06-22',
+      title: 'Mariners vs Astros',
+      venueId: v1.id,
+      attended: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const [e3] = await db
+      .insert(attendedEvents)
+      .values({
+        userId: 1,
+        category: 'music',
+        eventType: 'concert',
+        eventDate: '2024-09-12',
+        title: 'Phoebe Bridgers',
+        venueId: v2.id,
+        attended: 1,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+    // attended=0 — should be excluded
+    await db.insert(attendedEvents).values({
+      userId: 1,
+      category: 'sports',
+      eventType: 'mlb_game',
+      eventDate: '2024-07-04',
+      title: 'Skipped game',
+      venueId: v1.id,
+      attended: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    // Wrong year — should be excluded
+    await db.insert(attendedEvents).values({
+      userId: 1,
+      category: 'sports',
+      eventType: 'mlb_game',
+      eventDate: '2023-08-01',
+      title: 'Last year',
+      venueId: v1.id,
+      attended: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(attendedEventPerformers).values({
+      eventId: e3.id,
+      performerId: p1.id,
+      role: 'headliner',
+    });
+    await db.insert(attendedEventTickets).values({
+      userId: 1,
+      eventId: e1.id,
+      vendor: 'ticketmaster',
+      orderId: 'TM-1',
+      totalPriceCents: 12000,
+      currency: 'USD',
+      sourceType: 'gmail',
+      createdAt: now,
+    });
+
+    const res = await SELF.fetch('https://test/v1/attending/year/2024', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      year: number;
+      total_events: number;
+      total_spent_cents: number;
+      by_category: Array<{ category: string; count: number }>;
+      by_event_type: Array<{ event_type: string; count: number }>;
+      monthly: Array<{ month: string; count: number }>;
+      top_venues: Array<{ name: string; count: number }>;
+      top_performers: Array<{ name: string; count: number }>;
+      events: Array<{ title: string }>;
+    };
+
+    expect(body.year).toBe(2024);
+    expect(body.total_events).toBe(3);
+    expect(body.total_spent_cents).toBe(12000);
+
+    expect(body.by_category).toEqual(
+      expect.arrayContaining([
+        { category: 'sports', count: 2 },
+        { category: 'music', count: 1 },
+      ])
+    );
+    expect(body.by_event_type).toEqual(
+      expect.arrayContaining([
+        { event_type: 'mlb_game', count: 2 },
+        { event_type: 'concert', count: 1 },
+      ])
+    );
+
+    // Monthly array always has 12 rows; empty months are zero-filled.
+    expect(body.monthly).toHaveLength(12);
+    expect(body.monthly.find((m) => m.month === '2024-06')?.count).toBe(2);
+    expect(body.monthly.find((m) => m.month === '2024-09')?.count).toBe(1);
+    expect(body.monthly.find((m) => m.month === '2024-01')?.count).toBe(0);
+
+    expect(body.top_venues[0]).toMatchObject({
+      name: 'T-Mobile Park',
+      count: 2,
+    });
+    expect(body.top_performers[0]).toMatchObject({
+      name: 'Phoebe Bridgers',
+      count: 1,
+    });
+
+    expect(body.events).toHaveLength(3);
+    expect(body.events[0].title).toBe('Mariners vs Yankees'); // sorted by date asc
+  });
+});

--- a/src/routes/attending.ts
+++ b/src/routes/attending.ts
@@ -1,16 +1,18 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, lte, sql } from 'drizzle-orm';
 import { createDb } from '../db/client.js';
 import {
+  attendedEventPerformers,
   attendedEventPlayers,
   attendedEvents,
   attendedEventTickets,
+  performers,
   players,
   venues,
 } from '../db/schema/attending.js';
 import { setCache } from '../lib/cache.js';
 import { getImageAttachmentBatch } from '../lib/images.js';
-import { notFound } from '../lib/errors.js';
+import { badRequest, notFound } from '../lib/errors.js';
 import { createOpenAPIApp } from '../lib/openapi.js';
 import { errorResponses, PaginationMeta } from '../lib/schemas/common.js';
 
@@ -901,6 +903,247 @@ attending.openapi(playerDetailRoute, async (c) => {
             notable: a.notable === 1,
           };
         }),
+    },
+    200
+  );
+});
+
+// ─── GET /year/{year} ───────────────────────────────────────────────
+
+const YearParamSchema = z.object({
+  year: z.coerce
+    .number()
+    .int()
+    .openapi({
+      param: { name: 'year', in: 'path', required: true },
+      example: 2024,
+    }),
+});
+
+const YearInReviewSchema = z.object({
+  year: z.number(),
+  total_events: z.number(),
+  total_spent_cents: z.number(),
+  by_category: z.array(z.object({ category: z.string(), count: z.number() })),
+  by_event_type: z.array(
+    z.object({ event_type: z.string(), count: z.number() })
+  ),
+  monthly: z.array(
+    z.object({
+      month: z.string().openapi({ example: '2024-08' }),
+      count: z.number(),
+    })
+  ),
+  top_venues: z.array(
+    z.object({
+      venue_id: z.number(),
+      name: z.string(),
+      city: z.string().nullable(),
+      count: z.number(),
+    })
+  ),
+  top_performers: z.array(
+    z.object({
+      performer_id: z.number(),
+      name: z.string(),
+      count: z.number(),
+    })
+  ),
+  events: z.array(
+    z.object({
+      id: z.number(),
+      event_date: z.string(),
+      event_type: z.string(),
+      title: z.string(),
+      subtitle: z.string().nullable(),
+      venue_name: z.string().nullable(),
+    })
+  ),
+});
+
+const yearInReviewRoute = createRoute({
+  method: 'get',
+  path: '/year/{year}',
+  operationId: 'getAttendingYearInReview',
+  tags: ['Attending'],
+  summary: 'Year in review',
+  description:
+    'Returns a year-in-review summary for attended events: totals, monthly breakdown, top venues, top concert performers, and the full event list. 404 when no attended events exist for the year.',
+  request: {
+    params: YearParamSchema,
+  },
+  responses: {
+    200: {
+      description: 'Year in review',
+      content: { 'application/json': { schema: YearInReviewSchema } },
+    },
+    ...errorResponses(400, 401, 404),
+  },
+});
+
+attending.openapi(yearInReviewRoute, async (c) => {
+  const db = createDb(c.env.DB);
+  const { year } = c.req.valid('param');
+  const currentYear = new Date().getFullYear();
+
+  if (year < 2000 || year > currentYear + 1) {
+    return badRequest(c, 'Invalid year') as any;
+  }
+
+  setCache(c, year < currentYear ? 'long' : 'medium');
+
+  const startDate = `${year}-01-01`;
+  const endDate = `${year}-12-31`;
+  // event_date is venue-local YYYY-MM-DD; lexicographic comparison is
+  // safe within a year. attended=1 only — events you didn't actually go
+  // to don't count toward the recap.
+  const where = and(
+    eq(attendedEvents.userId, 1),
+    eq(attendedEvents.attended, 1),
+    gte(attendedEvents.eventDate, startDate),
+    lte(attendedEvents.eventDate, endDate)
+  );
+
+  // Six aggregates fan out in parallel; same pattern as the listening
+  // year-in-review (see commit 2d0a193 for the rationale).
+  const totalsP = db
+    .select({ total: sql<number>`count(*)` })
+    .from(attendedEvents)
+    .where(where);
+
+  const byCategoryP = db
+    .select({
+      category: attendedEvents.category,
+      count: sql<number>`count(*)`,
+    })
+    .from(attendedEvents)
+    .where(where)
+    .groupBy(attendedEvents.category)
+    .orderBy(desc(sql`count(*)`));
+
+  const byEventTypeP = db
+    .select({
+      event_type: attendedEvents.eventType,
+      count: sql<number>`count(*)`,
+    })
+    .from(attendedEvents)
+    .where(where)
+    .groupBy(attendedEvents.eventType)
+    .orderBy(desc(sql`count(*)`));
+
+  const monthlyRowsP = db
+    .select({
+      month: sql<string>`substr(${attendedEvents.eventDate}, 1, 7)`,
+      count: sql<number>`count(*)`,
+    })
+    .from(attendedEvents)
+    .where(where)
+    .groupBy(sql`substr(${attendedEvents.eventDate}, 1, 7)`)
+    .orderBy(asc(sql`substr(${attendedEvents.eventDate}, 1, 7)`));
+
+  const topVenuesP = db
+    .select({
+      venue_id: venues.id,
+      name: venues.name,
+      city: venues.city,
+      count: sql<number>`count(*)`,
+    })
+    .from(attendedEvents)
+    .innerJoin(venues, eq(venues.id, attendedEvents.venueId))
+    .where(where)
+    .groupBy(venues.id)
+    .orderBy(desc(sql`count(*)`))
+    .limit(5);
+
+  const topPerformersP = db
+    .select({
+      performer_id: performers.id,
+      name: performers.name,
+      count: sql<number>`count(*)`,
+    })
+    .from(attendedEventPerformers)
+    .innerJoin(
+      performers,
+      eq(performers.id, attendedEventPerformers.performerId)
+    )
+    .innerJoin(
+      attendedEvents,
+      eq(attendedEvents.id, attendedEventPerformers.eventId)
+    )
+    .where(where)
+    .groupBy(performers.id)
+    .orderBy(desc(sql`count(*)`))
+    .limit(5);
+
+  const totalSpentP = db
+    .select({
+      cents: sql<number>`coalesce(sum(${attendedEventTickets.totalPriceCents}), 0)`,
+    })
+    .from(attendedEventTickets)
+    .innerJoin(
+      attendedEvents,
+      eq(attendedEvents.id, attendedEventTickets.eventId)
+    )
+    .where(where);
+
+  const eventsListP = db
+    .select({
+      id: attendedEvents.id,
+      event_date: attendedEvents.eventDate,
+      event_type: attendedEvents.eventType,
+      title: attendedEvents.title,
+      subtitle: attendedEvents.subtitle,
+      venue_name: venues.name,
+    })
+    .from(attendedEvents)
+    .leftJoin(venues, eq(venues.id, attendedEvents.venueId))
+    .where(where)
+    .orderBy(asc(attendedEvents.eventDate));
+
+  const [
+    totals,
+    byCategory,
+    byEventType,
+    monthlyRows,
+    topVenues,
+    topPerformers,
+    totalSpent,
+    eventsList,
+  ] = await Promise.all([
+    totalsP,
+    byCategoryP,
+    byEventTypeP,
+    monthlyRowsP,
+    topVenuesP,
+    topPerformersP,
+    totalSpentP,
+    eventsListP,
+  ]);
+
+  const totalEvents = totals[0]?.total ?? 0;
+  if (totalEvents === 0) {
+    return notFound(c, `No attended events for year ${year}`) as any;
+  }
+
+  // Backfill missing months with zeros so consumers don't have to.
+  const monthlyMap = new Map(monthlyRows.map((r) => [r.month, r.count]));
+  const monthly = Array.from({ length: 12 }, (_, i) => {
+    const mm = String(i + 1).padStart(2, '0');
+    const key = `${year}-${mm}`;
+    return { month: key, count: monthlyMap.get(key) ?? 0 };
+  });
+
+  return c.json(
+    {
+      year,
+      total_events: totalEvents,
+      total_spent_cents: totalSpent[0]?.cents ?? 0,
+      by_category: byCategory,
+      by_event_type: byEventType,
+      monthly,
+      top_venues: topVenues,
+      top_performers: topPerformers,
+      events: eventsList,
     },
     200
   );


### PR DESCRIPTION
## Summary

Closes #66. Adds `GET /v1/attending/year/{year}` mirroring the listening + running year-in-review endpoints.

Response shape:
- `total_events` (attended=1 only) and `total_spent_cents`
- `by_category` and `by_event_type` counts
- `monthly` — 12-row zero-filled array
- `top_venues` (5) and `top_performers` (5)
- `events` — full attended-event list ordered by date

Eight aggregates run in parallel via `Promise.all` (same approach as listening's `2d0a193`). Returns 404 when no attended events for the year.

Also adds the `get_attending_year_in_review` MCP tool — text fallback (totals, by-event-type, top venues, top performers) + structuredContent for any card-UI follow-ups.

## Test plan

- [x] 3 integration tests against in-memory D1 covering 200 / 400 / 404 paths and aggregation correctness (attended=0 + wrong-year exclusion)
- [x] OpenAPI snapshot regenerated
- [x] MCP manifest snapshot regenerated; tool count bumped 45 → 46
- [x] `check:docs` clean (added the new tool to `docs-mintlify/mcp-server.mdx`)
- [x] Full suite: 909/909

🤖 Generated with [Claude Code](https://claude.com/claude-code)