### PR TITLE
Drop stuck Node 20 actions, bump release-please v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,19 +92,3 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level=moderate --omit=dev
-
-      - name: Scan for secrets
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary

Part of the cross-repo Node 24 migration ahead of GitHub's **June 2, 2026** runner cutover. Most of this repo's actions are already on Node 24 — this PR cleans up the three stragglers.

## Changes

**Drops two actions stuck at Node 20** (no Node 24 successor in sight):
- `gitleaks/gitleaks-action@v2` — last code change April 2025, license went proprietary in v2
- `actions/dependency-review-action@v4` — Node 24 PR #1084 stalled since April 8

Already replaced by GitHub-native equivalents enabled on this repo:
- Secret scanning + push protection
- Dependabot security updates
- The `Audit dependencies` step (`npm audit`) is retained in the security job

**Bumps:**
- `googleapis/release-please-action` v4 → **v5** (Node 24, released 2026-04-22; no behavior changes beyond runtime)

## Followup

The `GITLEAKS_LICENSE` repo secret is now unused and can be removed from repo settings when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)