### PR TITLE
ci: restore dependency-review job on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,13 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level=moderate --omit=dev
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v5


### PR DESCRIPTION
## What

Restores the `dependency-review` CI job that PR #98 removed, pinned to
`actions/dependency-review-action@v5`.

## Why

PR #98 dropped this job as a "stuck Node 20 action." That premise is
incorrect for this action — `dependency-review-action@v5` runs on the
Node 24 runtime (verified in its `action.yml`). It was removed for a
reason that does not apply.

`dependency-review` is a PR-time gate distinct from the existing
`npm audit` step:

- It scans only the dependencies a PR **adds or changes**, and can
  **fail the PR** on a known-vulnerable addition.
- `npm audit` runs in a `continue-on-error: true` job, so it monitors
  but gates nothing.

They are complementary — this catches a bad dependency before merge.

gitleaks secret scanning was also removed by #98 and is **intentionally
left out** — its action genuinely has no Node 24 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)