### PR TITLE
docs: changelog entry for MCP tool titles and output schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ migrations/                -- D1 SQL migration files
 mcp-server/                -- MCP server (npm: rewind-mcp-server), separate package
   src/
     tools/                 -- Tool definitions per domain
+      schemas/             -- Zod outputSchema per domain (z.infer drives the TS types)
     server.ts              -- MCP server setup, tool/resource/prompt registration
     client.ts              -- HTTP client for api.rewind.rest
     worker.ts              -- Cloudflare Worker entry (remote transport)

--- a/docs-mintlify/changelog.mdx
+++ b/docs-mintlify/changelog.mdx
@@ -3,6 +3,18 @@ title: Changelog
 description: API updates and new features.
 ---
 
+<Update label="May 15, 2026" tags={["Improvements"]}>
+
+## MCP server: tool titles and output schemas
+
+MCP tools are now clearer to read in the client and to consume programmatically.
+
+- **Display titles** — every tool, resource, and prompt shows a readable name in Claude Desktop and iOS, like "Now playing" or "Recent runs", instead of a raw identifier like `get_now_playing`.
+- **Output schemas** — schema-aware clients can render labeled fields from a tool's structured response; every tool now declares an `outputSchema`.
+- **`get_on_this_day` fix** — calling [`get_on_this_day`](/mcp-server#get_on_this_day) with no arguments returned an error; it now defaults to today.
+
+</Update>
+
 <Update label="April 29, 2026" tags={["Improvements"]}>
 
 ## Reading domain: full Instapaper archive


### PR DESCRIPTION
The public changelog was stale since April 29 — missing the MCP server work shipped since (#109, #112).

Adds a May 15 entry covering:
- Tool display titles (Claude Desktop/iOS show readable names)
- `outputSchema` on every tool
- the `get_on_this_day` no-arguments fix

Also adds the new `mcp-server/src/tools/schemas/` directory to the CLAUDE.md project-structure tree.

Written with the `changelog-writer` skill's reader-facing voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)