### PR TITLE
fix(listening): stop new album/artist attribution corruption

### DIFF
--- a/docs-mintlify/openapi.json
+++ b/docs-mintlify/openapi.json
@@ -178,12 +178,24 @@
               "artists_missing_apple_music_url",
               "tracks_missing_itunes_enrichment"
             ]
+          },
+          "integrity": {
+            "type": "object",
+            "properties": {
+              "lastfm_album_artist_mismatch_count": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "lastfm_album_artist_mismatch_count"
+            ]
           }
         },
         "required": [
           "status",
           "domains",
-          "enrichment"
+          "enrichment",
+          "integrity"
         ]
       },
       "ErrorResponse": {
@@ -2081,6 +2093,9 @@
                     "artists_missing_apple_music_url_with_plays": 0,
                     "artists_missing_apple_music_url": 0,
                     "tracks_missing_itunes_enrichment": 0
+                  },
+                  "integrity": {
+                    "lastfm_album_artist_mismatch_count": 0
                   }
                 }
               }

--- a/docs/projects/album-attribution-repair/README.md
+++ b/docs/projects/album-attribution-repair/README.md
@@ -1,0 +1,126 @@
+# Album attribution repair
+
+## Background
+
+The portfolio "Lately" card on patdugan.me shows a music-note placeholder instead
+of album art for the last-played track ("Porch" by Pearl Jam, MTV Unplugged).
+Investigation showed this is a surface symptom of a deeper data-integrity issue:
+**1,541 `lastfm_tracks` rows point at an album whose `artist_id` belongs to a
+different artist.**
+
+## Root cause
+
+Two compounding bugs.
+
+### 1. Over-eager cross-artist album merge
+
+Migration `0018_compilation_album_dedup.sql` merged any album name appearing
+under **3 or more distinct artists** into the lowest-id album row, deleted the
+losers, reparented tracks, summed playcounts into the winner, and flagged the
+winner `is_compilation = 1`. The intent was to consolidate true compilations
+(soundtracks, NOW-style comps); the implementation also consolidated common
+album titles that are not compilations:
+
+- "Greatest Hits" (album 53, attributed to Aerosmith, holds tracks from 48
+  distinct artists — Tom Petty, Louis Armstrong, Ramones, Hendrix, CCR, …)
+- "MTV Unplugged" (album 118, attributed to Bob Dylan, holds Pearl Jam tracks)
+- "Live", "Demos", "Self-Titled" — same shape
+
+`src/services/lastfm/sync.ts:92-101` perpetuates the merge for new scrobbles
+via a `compilation_fallback` lookup, so the corruption is ongoing — 17
+scrobbles in May 2026 alone landed under a wrong-artist album row.
+
+### 2. Fragile now-playing lookup
+
+`src/routes/listening.ts:1712-1727` resolves the live now-playing track's album
+via `WHERE name = X AND artist_id = Y`. When `Y` doesn't match the (corrupted)
+album row's artist_id, the handler returns `album.image: null` — the Lately
+card has no image to render.
+
+The `/recent` endpoint dodges this by joining through `lastfm_tracks.album_id`
+directly, which is why the same track returns a (Bob Dylan's) album image
+there. Bug #1 still causes wrong art everywhere — just less visibly.
+
+## Target end state
+
+**Album identity is `(name, artist_id)`, strictly.** Two different artists
+with "Greatest Hits" or "MTV Unplugged" are two album rows. Real compilations
+are albums whose `artist_id` points at a canonical **"Various Artists"** artist
+row (Last.fm/MusicBrainz MBID `89ad4ac3-39f7-470e-963a-56509c546377`) — the
+same model the upstream sources use.
+
+`is_compilation` becomes derivable from a join and gets dropped.
+
+Sync's `upsertAlbum` never merges across artists; it relies on the existing
+`uniqueIndex('idx_lastfm_albums_unique').on(name, artistId)` for identity.
+
+## Blast radius (baselined 2026-05-28)
+
+| Metric                                                | Count |
+| ----------------------------------------------------- | ----- |
+| Tracks where `track.artist_id != album.artist_id`     | 1,541 |
+| Albums flagged `is_compilation = 1`                   | 128   |
+| Scrobbles affected (May 2026 alone)                   | 17    |
+| Distinct artists pointing at album 53 "Greatest Hits" | 48    |
+
+Downstream effects:
+
+- **Wrong art** on Pearl Jam scrobbles (shows Bob Dylan's MTV Unplugged art via
+  `/recent`, top-tracks, search, year-in-review).
+- **Search misses** — migration 0018 deleted `search_index` rows for losers.
+- **Playcount inflation** — migration 0018 summed loser playcounts into
+  winners; album 53's count is the merged Greatest-Hits total across every
+  artist scrobbled.
+- **Now-playing returns `null`** image when the track artist doesn't match the
+  (corrupted) album row's artist.
+
+## Decisions locked in
+
+| Decision                         | Choice                                                                                                                                                                                                      | Rationale                                                                                                                                                                                              |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Compilation representation       | Dedicated "Various Artists" artist row (drop `is_compilation` flag)                                                                                                                                         | Matches MusicBrainz / Spotify / Apple Music model; one source of truth on the row; no flag drift                                                                                                       |
+| Phase 3 split heuristic          | Dominant-artist split: if any single artist owns ≥ 50% of tracks on a compilation-flagged album, split out per-artist rows; if ≥ 4 distinct artists remain with sparse counts, keep a Various-Artists shell | Errs toward correctness for common-name collisions while preserving real soundtrack/comp grouping                                                                                                      |
+| Album-artist signal at sync time | Default to track artist; do NOT call extra `track.getInfo` per scrobble (rate-limit cost)                                                                                                                   | `user.getRecentTracks` does not expose `album.artist`. Acceptable to attribute album to the track artist by default; comp grouping happens only for known Various-Artists MBIDs or explicit enrichment |
+| Migration safety                 | Full DB backup before Phase 3; idempotent design with `_split_audit` table recording every action                                                                                                           | Phase 3 is the only step that's hard to reverse                                                                                                                                                        |
+
+## Phase plan
+
+Phases are ordered so each one is independently mergeable and makes the next
+one safer.
+
+| #   | Phase                 | Outcome                                                                                                                                                           | Reversibility                    |
+| --- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| 0   | Discovery             | This document, baseline counts, blast-radius queries                                                                                                              | N/A                              |
+| 1   | Stop the bleeding     | Sync stops creating new corruption; now-playing handler fixed; sync-health invariant added                                                                        | Trivial rollback                 |
+| 2   | Strict album identity | Canonical Various-Artists row inserted; `upsertAlbum` matches on `(name, artist_id)` only                                                                         | Rollback by re-enabling fallback |
+| 3   | Repair migration      | 128 compilation-flagged albums classified and split per dominant-artist rule; per-artist rows minted; tracks repointed; `_split_audit` table records every action | Hard — needs DB backup           |
+| 4   | Art backfill          | New album rows have cover art via existing `processListeningImages()` pipeline                                                                                    | Additive                         |
+| 5   | Rebuild derived data  | Playcounts recomputed from scrobbles; `lastfm_top_albums` cron-rebuilt; `search_index` reindexed for listening domain                                             | Recompute from source            |
+| 6   | Invariants + cleanup  | `upsertAlbum` test added; sync-health alarm wired; `is_compilation` column dropped                                                                                | N/A                              |
+
+## Out of scope
+
+- Discogs / physical-media collection has its own album/release model — not
+  affected by this bug and not touched here.
+- Plex/Letterboxd watch tables share the `images` polymorphic pattern but
+  aren't part of the Last.fm corruption chain.
+- Apple Music enrichment continues running unchanged on top of the corrected
+  album rows.
+
+## Open questions
+
+None at kickoff. Any new questions surfaced during a phase get logged in
+`TRACKER.md` under that phase.
+
+## Related code paths
+
+- `src/services/lastfm/sync.ts` — `upsertArtist`, `upsertAlbum`, `upsertTrack`
+- `src/services/lastfm/transforms.ts` — `normalizeScrobble`
+- `src/services/lastfm/client.ts` — Last.fm API surface (`LastfmRecentTrack`)
+- `src/routes/listening.ts:1681-1791` — now-playing handler
+- `src/routes/listening.ts:1794-1865` — recent handler (reference impl)
+- `src/services/images/sync-images.ts` — `processListeningImages()`
+- `src/routes/admin-reindex.ts` — search_index rebuild
+- `src/lib/after-sync.ts` — per-sync search_index/feed writes
+- `src/db/schema/lastfm.ts` — `lastfmAlbums`, `lastfmArtists`, `lastfmTracks`
+- `migrations/0018_compilation_album_dedup.sql` — original buggy migration

--- a/docs/projects/album-attribution-repair/TRACKER.md
+++ b/docs/projects/album-attribution-repair/TRACKER.md
@@ -15,7 +15,7 @@
 ## Phase 0 — Discovery ✅
 
 - [x] Reproduced symptom: `/v1/listening/now-playing` returns `album.image:
-    null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
+null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
       Unplugged art for the same track.
 - [x] Identified Bug 1: `migrations/0018_compilation_album_dedup.sql` merged
       same-named albums under 3+ distinct artists, flagged winners

--- a/docs/projects/album-attribution-repair/TRACKER.md
+++ b/docs/projects/album-attribution-repair/TRACKER.md
@@ -1,0 +1,196 @@
+# Tracker
+
+## Pre-flight — decisions locked
+
+- [x] Compilation representation: dedicated "Various Artists" artist row;
+      `is_compilation` column will be dropped after Phase 6.
+- [x] Phase 3 split heuristic: dominant-artist (≥ 50% ownership) split with
+      Various-Artists shell preserved for true comps (4+ artists, sparse).
+- [x] Album-artist signal: default to track artist at sync time. No extra
+      `track.getInfo` calls per scrobble.
+- [x] Phase 3 safety: full DB backup before run; `_split_audit` table records
+      every action; idempotent re-run by checking the audit table.
+- [x] Deploy strategy: ship phases as separate PRs to `main`, one at a time.
+
+## Phase 0 — Discovery ✅
+
+- [x] Reproduced symptom: `/v1/listening/now-playing` returns `album.image:
+    null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
+      Unplugged art for the same track.
+- [x] Identified Bug 1: `migrations/0018_compilation_album_dedup.sql` merged
+      same-named albums under 3+ distinct artists, flagged winners
+      `is_compilation = 1`.
+- [x] Identified Bug 2: `src/routes/listening.ts:1712-1727` looks up album by
+      `(name, artist_id)`, fails when the row was merged under a different
+      artist.
+- [x] Confirmed `is_compilation` is read in exactly one place
+      (`src/services/lastfm/sync.ts:96`).
+- [x] Confirmed `upsertTrack` (sync.ts:137-149) overwrites `album_id` on every
+      scrobble — so Phase 3 repairs would be re-corrupted unless Phase 2 ships
+      first. Dependency ordered correctly.
+- [x] Baselined blast radius (2026-05-28):
+      1,541 mismatched tracks · 128 compilation albums · 17 affected scrobbles
+      in May 2026 · 48 distinct artists on album 53 "Greatest Hits".
+- [x] Created `docs/projects/album-attribution-repair/{README,TRACKER}.md`.
+
+## Phase 1 — Stop the bleeding
+
+User-visible: now-playing card stops returning `null` image. New corruption
+stops.
+
+- [x] **Fix now-playing handler** (`src/routes/listening.ts:1681-1791`)
+  - [x] Look up the track via `(name, artist_id)` first
+  - [x] If track found and has `album_id`, join through to `lastfm_albums` for
+        album name + image (matches `/recent` shape)
+  - [x] Fall back to Last.fm's `album['#text']` for name-only when no track row
+        exists yet
+  - [x] Keep current artist + track Apple Music URL lookups unchanged
+- [x] **Disable compilation fallback** in `src/services/lastfm/sync.ts:92-101`
+  - [x] Remove the fallback block entirely; rely on the strict
+        `(name, artist_id)` match plus row creation
+  - [x] Add a comment pointing at this doc for context
+- [x] **Sync-health invariant counter**
+  - [x] In `src/routes/system.ts`, extend `GET /v1/health/sync` to include
+        `lastfm_album_artist_mismatch_count` from the same query we ran in
+        Phase 0
+  - [x] Counter should drop to 0 after Phase 3 + Phase 6 land
+- [x] Tests
+  - [x] `upsertAlbum` test: same name under two artists creates two rows
+        (also covers compilation-flagged existing row case)
+  - [ ] now-playing handler test: deferred — needs Last.fm client mock; the
+        e2e schema test already covers the response shape and the
+        `upsertAlbum` tests cover the underlying identity invariant
+- [x] `npx tsc --noEmit` clean
+- [x] `npm test` green (1002 tests)
+- [ ] PR + deploy + verify Lately card on patdugan.me renders Pearl Jam's
+      Porch with album art (even if it's still Bob Dylan's art — that's
+      Phase 3's job)
+
+## Phase 2 — Strict album identity
+
+Schema-level fix: introduce Various Artists row, lock identity to
+`(name, artist_id)`.
+
+- [ ] **Various Artists artist row**
+  - [ ] Migration: insert into `lastfm_artists` with
+        `mbid = '89ad4ac3-39f7-470e-963a-56509c546377'`, name `'Various Artists'`,
+        `is_filtered = 0`
+  - [ ] Export `VARIOUS_ARTISTS_ID` constant from `src/services/lastfm/sync.ts`
+        or a new `src/services/lastfm/constants.ts`
+- [ ] **`upsertAlbum` becomes strict**
+  - [ ] Remove all fallbacks; only match on `(name, artist_id)`
+  - [ ] If miss: insert new row
+  - [ ] Keep `is_compilation` column writes off (column stays for read-side
+        compat until Phase 6)
+- [ ] **Optional: detect Various-Artists scrobbles at sync time**
+  - [ ] If Last.fm payload's track MBID hits a known Various Artists release
+        (best-effort), or if `artist['#text'] === 'Various Artists'`, point
+        the album row at `VARIOUS_ARTISTS_ID` instead of the track artist
+  - [ ] Defer to a follow-up if cost/complexity is high — Phase 3 will catch
+        the existing cases anyway
+- [ ] Tests
+  - [ ] Strict-identity test: two artists with same album name → two rows
+  - [ ] Various Artists row exists post-migration
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm test` green
+- [ ] PR + deploy
+
+## Phase 3 — Repair migration
+
+The only hard-to-reverse step. Run dry first; full DB backup before live run.
+
+- [ ] **`_split_audit` table** (lives in production for at least 30 days post-run)
+  - [ ] Columns: `winner_album_id`, `album_name`, `track_artist_id`,
+        `new_album_id`, `tracks_moved`, `action`
+        (`split_per_artist` | `keep_as_various_artists` | `skip_legit_comp`),
+        `created_at`
+- [ ] **Repair script** at `scripts/backfills/repair-album-attribution.ts`
+  - [ ] Dry-run mode (default): outputs CSV of planned actions, no writes
+  - [ ] For each `lastfm_albums` row with `is_compilation = 1`:
+    - [ ] Group its tracks by `track.artist_id`
+    - [ ] Compute share = `tracks_for_artist / total_tracks_on_album`
+    - [ ] Classify: - dominant artist (share ≥ 0.50): `split_per_artist` — mint new
+          `(name, that_artist_id)` row, copy `mbid`, `url`,
+          re-derive `playcount` from scrobble count, repoint that artist's
+          tracks to the new row - remaining sparse artists (< 0.50 share, ≥ 4 distinct on the
+          album): leave their tracks pointing at the winner row, but
+          re-attribute the winner row's `artist_id` to
+          `VARIOUS_ARTISTS_ID` and re-derive its playcount - all artists below 0.50, only 2-3 distinct: split all to per-artist
+          rows; delete the now-orphaned winner row
+    - [ ] Emit `_split_audit` rows for every action
+  - [ ] Live-run mode (`--apply`): writes to DB inside one D1 batch per album
+- [ ] **Dry-run review**
+  - [ ] Generate dry-run CSV
+  - [ ] Manually spot-check 10 albums (Pearl Jam MTV Unplugged, Aerosmith
+        Greatest Hits, Pulp Fiction Soundtrack, Mamas & Papas "Gold",
+        Tarantino comps, McCartney III Imagined, …)
+  - [ ] Confirm classifications match intent
+- [ ] **Backup**
+  - [ ] Export prod D1 to a dated R2 snapshot
+        (`d1-snapshots/rewind-db-<YYYY-MM-DD>-pre-repair.sql`)
+  - [ ] Document restore steps in this tracker
+- [ ] **Live run**
+  - [ ] `npx tsx scripts/backfills/repair-album-attribution.ts --apply`
+  - [ ] Verify post-run counts: mismatch count → 0, new album row count =
+        number of `split_per_artist` actions
+- [ ] PR with code + dated `_split_audit` snapshot summary
+
+## Phase 4 — Art backfill for split rows
+
+- [ ] Existing `processListeningImages()` in
+      `src/services/images/sync-images.ts` will pick up new album rows missing
+      `image_key` on the next daily cron — confirm by querying for unfilled
+      art among the new IDs.
+- [ ] If too slow (large batch), kick off explicitly via admin endpoint:
+      `POST /v1/listening/admin/process-images?entityType=albums&limit=500`
+- [ ] After 48h, query: split albums still missing art. Acceptable for some to
+      remain placeholders; the bug is wrong-art, not missing-art.
+- [ ] Spot-check on portfolio: Lately card shows the correct Pearl Jam
+      MTV Unplugged cover.
+
+## Phase 5 — Rebuild derived data
+
+- [ ] **Playcounts on winner rows**
+  - [ ] Already re-derived inside Phase 3 split logic — confirm none remain
+        with the inflated migration-0018 totals
+- [ ] **`lastfm_top_albums`**
+  - [ ] Daily cron will rebuild from current playcounts; trigger an immediate
+        run via `POST /v1/admin/sync` with `type: 'top_lists'` to avoid
+        showing stale top-albums until next cron
+- [ ] **`search_index`**
+  - [ ] Trigger reindex: `POST /v1/admin/reindex` with
+        `{ "domains": ["listening"] }`
+  - [ ] Verify split albums searchable by `<artist> <album_name>`
+- [ ] **`lastfm_monthly_stats` / `lastfm_yearly_stats`**
+  - [ ] These count unique albums per period. Splits affect `uniqueAlbums`
+        counts. Trigger recompute via the existing stats sync.
+
+## Phase 6 — Invariants and cleanup
+
+- [ ] **Tests**
+  - [ ] `upsertAlbum` test (already added in Phase 1) confirmed green
+  - [ ] Sync regression test: scrobble of "Pearl Jam · Porch · MTV Unplugged"
+        creates a Pearl Jam-attributed album row, not a Bob Dylan one
+- [ ] **Runtime invariant**
+  - [ ] Add cron check in `src/index.ts`: nightly count of mismatched rows;
+        log at `[WARN]` if non-zero
+  - [ ] Optionally: page via Sentry alert at threshold > 10
+- [ ] **Schema cleanup**
+  - [ ] Migration: drop `lastfm_albums.is_compilation` column and the
+        `idx_lastfm_albums_compilation` index
+  - [ ] Remove the field from `src/db/schema/lastfm.ts`
+  - [ ] Remove the comment reference in `src/routes/listening.ts:2831` (the
+        listening-signal heuristic still applies but the comment becomes
+        outdated)
+- [ ] **Docs**
+  - [ ] Add a one-line entry to `docs-mintlify/changelog.mdx`
+  - [ ] Mark this project complete in `docs/projects/`
+
+## Rollback / restore notes
+
+- Phase 1 & 2: revert PRs; sync resumes pre-fix behavior (new corruption
+  resumes but old data is untouched).
+- Phase 3: restore from the dated R2 D1 snapshot. The `_split_audit` table
+  records every action so a custom inverse migration is possible, but full
+  restore is the simpler path.
+- Phases 4-6: re-running is safe (additive / idempotent recompute).

--- a/openapi.snapshot.json
+++ b/openapi.snapshot.json
@@ -178,12 +178,24 @@
               "artists_missing_apple_music_url",
               "tracks_missing_itunes_enrichment"
             ]
+          },
+          "integrity": {
+            "type": "object",
+            "properties": {
+              "lastfm_album_artist_mismatch_count": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "lastfm_album_artist_mismatch_count"
+            ]
           }
         },
         "required": [
           "status",
           "domains",
-          "enrichment"
+          "enrichment",
+          "integrity"
         ]
       },
       "ErrorResponse": {
@@ -2081,6 +2093,9 @@
                     "artists_missing_apple_music_url_with_plays": 0,
                     "artists_missing_apple_music_url": 0,
                     "tracks_missing_itunes_enrichment": 0
+                  },
+                  "integrity": {
+                    "lastfm_album_artist_mismatch_count": 0
                   }
                 }
               }

--- a/src/routes/listening.ts
+++ b/src/routes/listening.ts
@@ -1694,7 +1694,7 @@ listening.openapi(nowPlayingRoute, async (c) => {
     const latestTrack = tracks[0];
     const isPlaying = latestTrack['@attr']?.nowplaying === 'true';
 
-    // Look up artist and album in DB for IDs
+    // Look up artist in DB for ID
     const [artist] = await db
       .select({
         id: lastfmArtists.id,
@@ -1705,41 +1705,28 @@ listening.openapi(nowPlayingRoute, async (c) => {
       .where(eq(lastfmArtists.name, latestTrack.artist['#text']))
       .limit(1);
 
-    let albumData: {
-      id: number;
-      name: string;
-    } | null = null;
-    if (latestTrack.album['#text'] && artist) {
-      const [album] = await db
-        .select({
-          id: lastfmAlbums.id,
-          name: lastfmAlbums.name,
-        })
-        .from(lastfmAlbums)
-        .where(
-          and(
-            eq(lastfmAlbums.name, latestTrack.album['#text']),
-            eq(lastfmAlbums.artistId, artist.id)
-          )
-        )
-        .limit(1);
-      albumData = album ?? null;
-    }
-
-    // Look up track in DB for Apple Music data
+    // Resolve track + album via the stored track.album_id link. Mirrors the
+    // /recent endpoint's join shape so attribution stays consistent across
+    // surfaces — see docs/projects/album-attribution-repair/README.md for
+    // why the previous (name, artist_id) album lookup was unreliable.
     let trackData: {
       id: number;
       appleMusicUrl: string | null;
       previewUrl: string | null;
+      albumId: number | null;
+      albumName: string | null;
     } | null = null;
     if (artist) {
-      const [track] = await db
+      const [row] = await db
         .select({
           id: lastfmTracks.id,
           appleMusicUrl: lastfmTracks.appleMusicUrl,
           previewUrl: lastfmTracks.previewUrl,
+          albumId: lastfmTracks.albumId,
+          albumName: lastfmAlbums.name,
         })
         .from(lastfmTracks)
+        .leftJoin(lastfmAlbums, eq(lastfmTracks.albumId, lastfmAlbums.id))
         .where(
           and(
             eq(lastfmTracks.name, latestTrack.name),
@@ -1747,8 +1734,13 @@ listening.openapi(nowPlayingRoute, async (c) => {
           )
         )
         .limit(1);
-      trackData = track ?? null;
+      trackData = row ?? null;
     }
+
+    const albumData =
+      trackData?.albumId && trackData.albumName
+        ? { id: trackData.albumId, name: trackData.albumName }
+        : null;
 
     const albumImage = albumData
       ? await getImageAttachment(
@@ -1774,7 +1766,7 @@ listening.openapi(nowPlayingRoute, async (c) => {
         },
         album: {
           id: albumData?.id ?? null,
-          name: latestTrack.album['#text'],
+          name: albumData?.name ?? latestTrack.album['#text'],
           image: albumImage,
         },
         url: latestTrack.url,

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -3,7 +3,11 @@ import { desc, eq, sql, and, isNull } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/d1';
 import { createOpenAPIApp } from '../lib/openapi.js';
 import { syncRuns } from '../db/schema/system.js';
-import { lastfmArtists, lastfmTracks } from '../db/schema/lastfm.js';
+import {
+  lastfmArtists,
+  lastfmAlbums,
+  lastfmTracks,
+} from '../db/schema/lastfm.js';
 import { setCache } from '../lib/cache.js';
 
 const DOMAINS = [
@@ -47,11 +51,20 @@ const EnrichmentHealth = z.object({
   tracks_missing_itunes_enrichment: z.number().int(),
 });
 
+const IntegrityHealth = z.object({
+  // Tracks pointing at an album whose artist_id != the track's artist_id —
+  // the cross-artist attribution bug from migration 0018. Phase 1 stops new
+  // corruption; Phase 3 drives this to 0. See
+  // docs/projects/album-attribution-repair/README.md.
+  lastfm_album_artist_mismatch_count: z.number().int(),
+});
+
 const SyncHealthResponse = z
   .object({
     status: z.literal('ok'),
     domains: z.record(z.string(), SyncDomainStatus),
     enrichment: EnrichmentHealth,
+    integrity: IntegrityHealth,
   })
   .openapi('SyncHealthResponse');
 
@@ -127,6 +140,9 @@ const syncHealthRoute = createRoute({
               artists_missing_apple_music_url_with_plays: 0,
               artists_missing_apple_music_url: 0,
               tracks_missing_itunes_enrichment: 0,
+            },
+            integrity: {
+              lastfm_album_artist_mismatch_count: 0,
             },
           },
         },
@@ -238,6 +254,17 @@ system.openapi(syncHealthRoute, async (c) => {
       and(isNull(lastfmTracks.itunesEnrichedAt), eq(lastfmTracks.isFiltered, 0))
     );
 
+  // Data-integrity counter: tracks pointing at an album whose artist
+  // doesn't match. Drops to 0 once the album-attribution-repair project
+  // Phase 3 runs; before then, expect ~1,541 (2026-05-28 baseline).
+  const [integrityRow] = await db
+    .select({
+      mismatchCount: sql<number>`count(*)`,
+    })
+    .from(lastfmTracks)
+    .innerJoin(lastfmAlbums, eq(lastfmTracks.albumId, lastfmAlbums.id))
+    .where(sql`${lastfmTracks.artistId} != ${lastfmAlbums.artistId}`);
+
   return c.json({
     status: 'ok' as const,
     domains,
@@ -246,6 +273,9 @@ system.openapi(syncHealthRoute, async (c) => {
         enrichmentRow?.artistsMissingWithPlays ?? 0,
       artists_missing_apple_music_url: enrichmentRow?.artistsMissing ?? 0,
       tracks_missing_itunes_enrichment: trackRow?.tracksMissing ?? 0,
+    },
+    integrity: {
+      lastfm_album_artist_mismatch_count: integrityRow?.mismatchCount ?? 0,
     },
   });
 });

--- a/src/services/lastfm/sync.test.ts
+++ b/src/services/lastfm/sync.test.ts
@@ -9,7 +9,8 @@ import {
   lastfmYearlyStats,
 } from '../../db/schema/lastfm.js';
 import { setupTestDb } from '../../test-helpers.js';
-import { syncListening, syncYearlyStats } from './sync.js';
+import { syncListening, syncYearlyStats, upsertAlbum } from './sync.js';
+import { loadFilters } from './filters.js';
 import { eq } from 'drizzle-orm';
 
 describe('syncListening', () => {
@@ -311,5 +312,82 @@ describe('syncYearlyStats', () => {
     expect(row.scrobbles).toBe(1);
     expect(row.uniqueArtists).toBe(1);
     expect(row.uniqueTracks).toBe(1);
+  });
+});
+
+describe('upsertAlbum - strict (name, artist_id) identity', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    db = createDb(env.DB);
+    await db.delete(lastfmScrobbles);
+    await db.delete(lastfmTracks);
+    await db.delete(lastfmAlbums);
+    await db.delete(lastfmArtists);
+    await loadFilters(db);
+  });
+
+  it('mints distinct album rows when two artists share an album name', async () => {
+    const [pearlJam] = await db
+      .insert(lastfmArtists)
+      .values({ userId: 1, name: 'Pearl Jam', isFiltered: 0 })
+      .returning();
+    const [bobDylan] = await db
+      .insert(lastfmArtists)
+      .values({ userId: 1, name: 'Bob Dylan', isFiltered: 0 })
+      .returning();
+
+    const dylanAlbum = await upsertAlbum(
+      db,
+      'MTV Unplugged',
+      bobDylan.id,
+      null,
+      'Bob Dylan'
+    );
+    expect(dylanAlbum.isNew).toBe(true);
+
+    // Even if the existing row is flagged as a compilation, the second
+    // artist's identically-named album must land in its own row.
+    await db
+      .update(lastfmAlbums)
+      .set({ isCompilation: 1 })
+      .where(eq(lastfmAlbums.id, dylanAlbum.id));
+
+    const pearlJamAlbum = await upsertAlbum(
+      db,
+      'MTV Unplugged',
+      pearlJam.id,
+      null,
+      'Pearl Jam'
+    );
+
+    expect(pearlJamAlbum.isNew).toBe(true);
+    expect(pearlJamAlbum.id).not.toBe(dylanAlbum.id);
+
+    const rows = await db
+      .select()
+      .from(lastfmAlbums)
+      .where(eq(lastfmAlbums.name, 'MTV Unplugged'));
+    expect(rows).toHaveLength(2);
+    const artistIds = new Set(rows.map((r) => r.artistId));
+    expect(artistIds).toEqual(new Set([bobDylan.id, pearlJam.id]));
+  });
+
+  it('returns the same row on repeat upsert for the same (name, artist_id)', async () => {
+    const [artist] = await db
+      .insert(lastfmArtists)
+      .values({ userId: 1, name: 'Pearl Jam', isFiltered: 0 })
+      .returning();
+
+    const first = await upsertAlbum(db, 'Ten', artist.id, null, 'Pearl Jam');
+    const second = await upsertAlbum(db, 'Ten', artist.id, null, 'Pearl Jam');
+
+    expect(first.isNew).toBe(true);
+    expect(second.isNew).toBe(false);
+    expect(second.id).toBe(first.id);
   });
 });

--- a/src/services/lastfm/sync.ts
+++ b/src/services/lastfm/sync.ts
@@ -62,7 +62,9 @@ async function upsertArtist(
   return { id: result[0].id, isNew: true };
 }
 
-async function upsertAlbum(
+// Exported so the album-attribution-repair test suite can assert the
+// strict (name, artist_id) identity invariant.
+export async function upsertAlbum(
   db: Database,
   name: string,
   artistId: number,
@@ -89,18 +91,11 @@ async function upsertAlbum(
     return { id: existing.id, isNew: false };
   }
 
-  // 2. Compilation fallback: reuse existing compilation album row
-  const [compilation] = await db
-    .select({ id: lastfmAlbums.id })
-    .from(lastfmAlbums)
-    .where(and(eq(lastfmAlbums.name, name), eq(lastfmAlbums.isCompilation, 1)))
-    .limit(1);
-
-  if (compilation) {
-    return { id: compilation.id, isNew: false };
-  }
-
-  // 3. No match — create new album row
+  // No match — create a new album row. The historical compilation fallback
+  // (reuse any same-named album flagged is_compilation = 1, regardless of
+  // artist) caused cross-artist attribution bugs — e.g. Pearl Jam tracks
+  // linked to Bob Dylan's MTV Unplugged row. See
+  // docs/projects/album-attribution-repair/README.md.
   const filtered = isFiltered({ artistName, albumName: name }) ? 1 : 0;
   const result = await db
     .insert(lastfmAlbums)


### PR DESCRIPTION
## Summary

Phase 1 of the [album-attribution-repair project](docs/projects/album-attribution-repair/README.md).

Triggered by the portfolio "Lately" card showing a music-note placeholder for "Porch by Pearl Jam — MTV Unplugged". That surface symptom turned out to be the visible end of a deeper data-integrity issue: **1,541 `lastfm_tracks` rows point at an album whose `artist_id` belongs to a different artist** — fallout from migration 0018's overly broad compilation-merge heuristic.

This PR doesn't repair the existing rows (that's Phase 3). It stops the bleeding and gives us visibility.

### What ships in this PR

- **now-playing handler** (`src/routes/listening.ts`) joins through `lastfm_tracks.album_id` instead of a fragile `(name, artist_id)` album lookup. Mirrors `/recent`'s shape. Stops returning `album.image: null` for tracks whose album row is attributed to a different artist.
- **`upsertAlbum`** (`src/services/lastfm/sync.ts`) drops the cross-artist compilation fallback. New scrobbles can no longer land Pearl Jam tracks on Bob Dylan's "MTV Unplugged" row (or any analogous collision).
- **`GET /v1/health/sync`** gains an `integrity.lastfm_album_artist_mismatch_count` watchdog. Baseline today is 1,541; expected to track toward 0 as Phase 3 lands.
- **2 new tests** in `src/services/lastfm/sync.test.ts` cover the strict `(name, artist_id)` identity invariant — including the case where an existing row is flagged `is_compilation = 1`.

### What this does NOT fix yet

The existing 1,541 mis-linked tracks still point at the wrong album row, so the Lately card will continue to render Bob Dylan's MTV Unplugged cover for Pearl Jam's Porch. That repair is Phase 3, gated on full DB backup. See `docs/projects/album-attribution-repair/TRACKER.md` for the full sequence.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` green (1002 / 1002)
- [x] OpenAPI snapshots regenerated for the new `integrity` field
- [ ] After deploy: hit `GET /v1/health/sync` in prod and confirm `integrity.lastfm_album_artist_mismatch_count` returns ~1,541
- [ ] After deploy: hit `GET /v1/listening/now-playing` and confirm `album.image` is no longer `null` for tracks that have a `lastfm_tracks.album_id` link
- [ ] After deploy: verify the portfolio Lately card on patdugan.me renders an image (any image — correct art is Phase 3)