### PR TITLE
feat(listening): nightly album-attribution integrity watchdog

### DIFF
--- a/docs/projects/album-attribution-repair/TRACKER.md
+++ b/docs/projects/album-attribution-repair/TRACKER.md
@@ -15,8 +15,8 @@
 ## Phase 0 — Discovery ✅
 
 - [x] Reproduced symptom: `/v1/listening/now-playing` returns `album.image:
-null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
-      Unplugged art for the same track.
+  null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
+  Unplugged art for the same track.
 - [x] Identified Bug 1: `migrations/0018_compilation_album_dedup.sql` merged
       same-named albums under 3+ distinct artists, flagged winners
       `is_compilation = 1`.

--- a/docs/projects/album-attribution-repair/TRACKER.md
+++ b/docs/projects/album-attribution-repair/TRACKER.md
@@ -15,8 +15,8 @@
 ## Phase 0 — Discovery ✅
 
 - [x] Reproduced symptom: `/v1/listening/now-playing` returns `album.image:
-  null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
-  Unplugged art for the same track.
+null` for Porch by Pearl Jam while `/recent` returns Bob Dylan's MTV
+      Unplugged art for the same track.
 - [x] Identified Bug 1: `migrations/0018_compilation_album_dedup.sql` merged
       same-named albums under 3+ distinct artists, flagged winners
       `is_compilation = 1`.
@@ -184,7 +184,7 @@ and the daily cron.
 - [x] **Runtime invariant** — nightly integrity check
   - [x] Daily `0 3` cron computes mismatch count excluding the canonical
         Various Artists row; logs `[WARN]` when non-zero, `[INTEGRITY]
-    album attribution clean` otherwise
+album attribution clean` otherwise
   - [ ] Optionally page via Sentry at a threshold once a steady-state
         baseline is established
 - [ ] **Schema cleanup** — deferred to a follow-up PR

--- a/docs/projects/album-attribution-repair/TRACKER.md
+++ b/docs/projects/album-attribution-repair/TRACKER.md
@@ -145,53 +145,59 @@ The only hard-to-reverse step. Run dry first; full DB backup before live run.
 
 ## Phase 4 — Art backfill for split rows
 
-- [ ] Existing `processListeningImages()` in
-      `src/services/images/sync-images.ts` will pick up new album rows missing
-      `image_key` on the next daily cron — confirm by querying for unfilled
-      art among the new IDs.
-- [ ] If too slow (large batch), kick off explicitly via admin endpoint:
-      `POST /v1/listening/admin/process-images?entityType=albums&limit=500`
-- [ ] After 48h, query: split albums still missing art. Acceptable for some to
+Operational; no new code. The Phase 3 apply creates new album rows
+without `image_key`; the existing image pipeline fills them in.
+
+- [ ] After Phase 3 applies, immediately trigger the admin backfill:
+      `curl -X POST -H "Authorization: Bearer rw_..." -H "Content-Type: application/json" \`
+      `-d '{"type":"albums","limit":200}' https://api.rewind.rest/v1/listening/admin/backfill-images`
+      Re-run until `succeeded + skipped` covers all new rows
+      (or wait for the daily `0 3` cron to drain the queue).
+- [ ] After 48 h, query albums still missing art. Acceptable for some to
       remain placeholders; the bug is wrong-art, not missing-art.
 - [ ] Spot-check on portfolio: Lately card shows the correct Pearl Jam
       MTV Unplugged cover.
 
 ## Phase 5 — Rebuild derived data
 
-- [ ] **Playcounts on winner rows**
-  - [ ] Already re-derived inside Phase 3 split logic — confirm none remain
-        with the inflated migration-0018 totals
-- [ ] **`lastfm_top_albums`**
-  - [ ] Daily cron will rebuild from current playcounts; trigger an immediate
-        run via `POST /v1/admin/sync` with `type: 'top_lists'` to avoid
-        showing stale top-albums until next cron
-- [ ] **`search_index`**
-  - [ ] Trigger reindex: `POST /v1/admin/reindex` with
-        `{ "domains": ["listening"] }`
-  - [ ] Verify split albums searchable by `<artist> <album_name>`
-- [ ] **`lastfm_monthly_stats` / `lastfm_yearly_stats`**
-  - [ ] These count unique albums per period. Splits affect `uniqueAlbums`
-        counts. Trigger recompute via the existing stats sync.
+Operational; no new code. Playcounts are recomputed by Phase 3 apply.
+The remaining derived data is regenerated via existing admin endpoints
+and the daily cron.
+
+- [ ] **`lastfm_top_albums`** — trigger an immediate rebuild:
+      `curl -X POST -H "Authorization: Bearer rw_..." -H "Content-Type: application/json" \`
+      `-d '{"type":"top_lists"}' https://api.rewind.rest/v1/admin/sync/listening`
+- [ ] **`search_index`** — reindex listening:
+      `curl -X POST -H "Authorization: Bearer rw_..." -H "Content-Type: application/json" \`
+      `-d '{"domains":["listening"]}' https://api.rewind.rest/v1/admin/reindex-search`
+- [ ] **`lastfm_monthly_stats` / `lastfm_yearly_stats`** — kick the stats
+      sync (counts unique albums per period; splits change those counts):
+      `curl -X POST -H "Authorization: Bearer rw_..." -H "Content-Type: application/json" \`
+      `-d '{"type":"stats"}' https://api.rewind.rest/v1/admin/sync/listening`
 
 ## Phase 6 — Invariants and cleanup
 
-- [ ] **Tests**
-  - [ ] `upsertAlbum` test (already added in Phase 1) confirmed green
-  - [ ] Sync regression test: scrobble of "Pearl Jam · Porch · MTV Unplugged"
-        creates a Pearl Jam-attributed album row, not a Bob Dylan one
-- [ ] **Runtime invariant**
-  - [ ] Add cron check in `src/index.ts`: nightly count of mismatched rows;
-        log at `[WARN]` if non-zero
-  - [ ] Optionally: page via Sentry alert at threshold > 10
-- [ ] **Schema cleanup**
-  - [ ] Migration: drop `lastfm_albums.is_compilation` column and the
+- [x] **Tests**
+  - [x] `upsertAlbum` strict-identity test (Phase 1)
+  - [x] `upsertArtist` MBID-first lookup test (Phase 2)
+  - [x] `planRepair` + `applyRepair` test suite (Phase 3)
+- [x] **Runtime invariant** — nightly integrity check
+  - [x] Daily `0 3` cron computes mismatch count excluding the canonical
+        Various Artists row; logs `[WARN]` when non-zero, `[INTEGRITY]
+    album attribution clean` otherwise
+  - [ ] Optionally page via Sentry at a threshold once a steady-state
+        baseline is established
+- [ ] **Schema cleanup** — deferred to a follow-up PR
+      after Phase 3 has applied in prod and the audit table has been
+      observed for ≥ 30 days
+  - [ ] Drop `lastfm_albums.is_compilation` column + the
         `idx_lastfm_albums_compilation` index
   - [ ] Remove the field from `src/db/schema/lastfm.ts`
-  - [ ] Remove the comment reference in `src/routes/listening.ts:2831` (the
-        listening-signal heuristic still applies but the comment becomes
-        outdated)
+  - [ ] Remove the obsolete comment reference in
+        `src/routes/listening.ts:2831`
 - [ ] **Docs**
-  - [ ] Add a one-line entry to `docs-mintlify/changelog.mdx`
+  - [ ] Add a one-line entry to `docs-mintlify/changelog.mdx` once the
+        live apply has run
   - [ ] Mark this project complete in `docs/projects/`
 
 ## Rollback / restore notes

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,46 @@ export default {
                 `[ERROR] Last.fm similar-artists enrichment failed: ${err instanceof Error ? err.message : String(err)}`
               );
             }
+
+            // Album-attribution-repair integrity watchdog. Counts tracks
+            // whose artist_id doesn't match their album's artist_id
+            // (excluding albums attributed to the canonical Various
+            // Artists row, where the mismatch is correct by design).
+            // Post-Phase-3-apply this should be small and stable; growth
+            // signals a sync regression. See
+            // docs/projects/album-attribution-repair/.
+            try {
+              const { sql } = await import('drizzle-orm');
+              const { lastfmAlbums, lastfmTracks } =
+                await import('./db/schema/lastfm.js');
+              const { getVariousArtistsId } =
+                await import('./services/lastfm/constants.js');
+              const vaId = await getVariousArtistsId(db);
+              const [row] = await db
+                .select({ n: sql<number>`count(*)` })
+                .from(lastfmTracks)
+                .innerJoin(
+                  lastfmAlbums,
+                  sql`${lastfmTracks.albumId} = ${lastfmAlbums.id}`
+                )
+                .where(
+                  vaId === null
+                    ? sql`${lastfmTracks.artistId} != ${lastfmAlbums.artistId}`
+                    : sql`${lastfmTracks.artistId} != ${lastfmAlbums.artistId} AND ${lastfmAlbums.artistId} != ${vaId}`
+                );
+              const mismatch = Number(row?.n ?? 0);
+              if (mismatch > 0) {
+                console.log(
+                  `[WARN] album-attribution integrity: ${mismatch} tracks where track.artist_id != album.artist_id`
+                );
+              } else {
+                console.log('[INTEGRITY] album attribution clean');
+              }
+            } catch (err) {
+              console.log(
+                `[ERROR] integrity check failed: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
           })()
         );
         break;


### PR DESCRIPTION
## Summary

Phase 6 of the [album-attribution-repair project](docs/projects/album-attribution-repair/README.md). Stacks on #123 — review order is 121 → 122 → 123 → this.

Closes out the project's code work. Phases 4 (art backfill) and Phase 5 (rebuild derived data) are operational runbook steps — no code, just curl commands against existing admin endpoints — so they're documented in `TRACKER.md` rather than shipped here.

### What ships

- **Nightly integrity check** wired into the daily `0 3` listening cron. Counts tracks where `track.artist_id != album.artist_id`, excluding the canonical Various Artists row (where mismatch is correct by design). Logs `[WARN]` when non-zero, `[INTEGRITY] album attribution clean` otherwise. The check sits on the same surface that exposed the original Pearl Jam bug — if a sync regression re-introduces cross-artist linkage, this catches it before the user does.
- **Phase 4 / 5 runbook** added to TRACKER. The operational steps to run post-Phase-3-apply are now exact curl commands instead of vague prose.

### What's deferred

- **`is_compilation` column drop.** The flag is no longer read anywhere in the code, but I'm holding the schema change until Phase 3 has applied in prod and the audit table has been observed for ≥ 30 days. Comes as a follow-up PR once we're confident the apply is durable.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` green (1013 / 1013)
- [ ] After deploy: confirm the nightly cron logs either `[INTEGRITY] album attribution clean` or a `[WARN] ... N tracks` line (visible in `wrangler tail`)