### PR TITLE
fix(admin-reindex): stream listening domain via SQL pagination

### DIFF
--- a/src/routes/admin-reindex.test.ts
+++ b/src/routes/admin-reindex.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { env, SELF } from 'cloudflare:test';
+import { sql } from 'drizzle-orm';
 import { createDb } from '../db/client.js';
 import { readingItems } from '../db/schema/reading.js';
+import {
+  lastfmAlbums,
+  lastfmArtists,
+  lastfmTracks,
+} from '../db/schema/lastfm.js';
 import { setupTestDbWithFts5, createTestApiKey } from '../test-helpers.js';
 
 describe('POST /v1/admin/reindex-search', () => {
@@ -74,6 +80,113 @@ describe('POST /v1/admin/reindex-search', () => {
     const searchBody = (await searchRes.json()) as any;
     expect(searchBody.data.length).toBe(1);
     expect(searchBody.data[0].title).toContain('snl');
+  });
+
+  it('streams listening across artist/album/track segments without buildAllThenSlice', async () => {
+    const db = createDb(env.DB);
+    await db.delete(lastfmTracks);
+    await db.delete(lastfmAlbums);
+    await db.delete(lastfmArtists);
+
+    const [artist] = await db
+      .insert(lastfmArtists)
+      .values({ userId: 1, name: 'Pearl Jam', isFiltered: 0 })
+      .returning();
+    const [album] = await db
+      .insert(lastfmAlbums)
+      .values({
+        userId: 1,
+        name: 'MTV Unplugged',
+        artistId: artist.id,
+        isFiltered: 0,
+      })
+      .returning();
+    await db.insert(lastfmTracks).values({
+      userId: 1,
+      name: 'Porch',
+      artistId: artist.id,
+      albumId: album.id,
+      isFiltered: 0,
+    });
+
+    // Tiny chunk_size proves the segment cursor works across boundaries.
+    const total = 3;
+    for (let offset = 0; offset < total; offset += 1) {
+      const res = await SELF.fetch('http://localhost/v1/admin/reindex-search', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          domains: ['listening'],
+          chunk_size: 1,
+          chunk_offset: offset,
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.domains.listening.total).toBe(total);
+      expect(body.domains.listening.indexed).toBe(1);
+    }
+
+    const rows = await db.all<{ entity_type: string; title: string }>(
+      sql`SELECT entity_type, title FROM search_index WHERE domain = 'listening' ORDER BY entity_type`
+    );
+    const byType = rows.reduce<Record<string, string[]>>((acc, r) => {
+      (acc[r.entity_type] = acc[r.entity_type] ?? []).push(r.title);
+      return acc;
+    }, {});
+    // search_index normalizes to lowercase before storing.
+    expect(byType.artist).toEqual(['pearl jam']);
+    expect(byType.album).toEqual(['mtv unplugged']);
+    expect(byType.track).toEqual(['porch']);
+  });
+
+  it('uses joined artist name as subtitle for album + track rows', async () => {
+    const db = createDb(env.DB);
+    await db.delete(lastfmTracks);
+    await db.delete(lastfmAlbums);
+    await db.delete(lastfmArtists);
+
+    const [artist] = await db
+      .insert(lastfmArtists)
+      .values({ userId: 1, name: 'Bob Dylan', isFiltered: 0 })
+      .returning();
+    const [album] = await db
+      .insert(lastfmAlbums)
+      .values({
+        userId: 1,
+        name: 'Blood on the Tracks',
+        artistId: artist.id,
+        isFiltered: 0,
+      })
+      .returning();
+    await db.insert(lastfmTracks).values({
+      userId: 1,
+      name: 'Tangled Up in Blue',
+      artistId: artist.id,
+      albumId: album.id,
+      isFiltered: 0,
+    });
+
+    const res = await SELF.fetch('http://localhost/v1/admin/reindex-search', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ domains: ['listening'] }),
+    });
+    expect(res.status).toBe(200);
+
+    const rows = await db.all<{ entity_type: string; subtitle: string | null }>(
+      sql`SELECT entity_type, subtitle FROM search_index WHERE domain = 'listening'`
+    );
+    const albumSubtitle = rows.find((r) => r.entity_type === 'album')?.subtitle;
+    const trackSubtitle = rows.find((r) => r.entity_type === 'track')?.subtitle;
+    expect(albumSubtitle).toBe('bob dylan');
+    expect(trackSubtitle).toBe('bob dylan');
   });
 
   it('defaults to all domains when body is empty', async () => {

--- a/src/routes/admin-reindex.ts
+++ b/src/routes/admin-reindex.ts
@@ -550,7 +550,7 @@ async function buildSearchItemsForDomain(
     case 'watching':
       return buildAllThenSlice(buildWatching, db, offset, limit);
     case 'listening':
-      return buildAllThenSlice(buildListening, db, offset, limit);
+      return buildListening(db, offset, limit);
     case 'running':
       return buildAllThenSlice(buildRunning, db, offset, limit);
     case 'collecting':
@@ -687,63 +687,122 @@ async function buildWatching(
   }));
 }
 
+// Streaming reindex for listening. The combined stream is
+//   artists  [0,                   artistCount)
+//   albums   [artistCount,         artistCount + albumCount)
+//   tracks   [artistCount + albumCount, total)
+// Album/track subtitle is the artist name, joined at SQL time to avoid
+// materializing the full artist map. Mirrors buildReading's
+// segment-by-segment cursor so the legacy buildAllThenSlice path
+// (which loaded all ~46K rows into Worker memory) is no longer needed
+// for this domain.
 async function buildListening(
-  db: ReturnType<typeof createDb>
-): Promise<SearchIndexItem[]> {
-  const items: SearchIndexItem[] = [];
-
-  const artists = await db
-    .select({ id: lastfmArtists.id, name: lastfmArtists.name })
+  db: ReturnType<typeof createDb>,
+  offset: number,
+  limit: number
+): Promise<BuiltChunk> {
+  const artistCountRow = await db
+    .select({ c: sql<number>`count(*)` })
     .from(lastfmArtists)
     .where(eq(lastfmArtists.userId, 1));
-  const artistNameById = new Map<number, string>();
-  for (const a of artists) {
-    artistNameById.set(a.id, a.name);
-    items.push({
-      domain: 'listening',
-      entityType: 'artist',
-      entityId: String(a.id),
-      title: a.name,
-    });
-  }
+  const artistCount = Number(artistCountRow[0]?.c ?? 0);
 
-  const albums = await db
-    .select({
-      id: lastfmAlbums.id,
-      name: lastfmAlbums.name,
-      artistId: lastfmAlbums.artistId,
-    })
+  const albumCountRow = await db
+    .select({ c: sql<number>`count(*)` })
     .from(lastfmAlbums)
     .where(eq(lastfmAlbums.userId, 1));
-  for (const al of albums) {
-    items.push({
-      domain: 'listening',
-      entityType: 'album',
-      entityId: String(al.id),
-      title: al.name,
-      subtitle: artistNameById.get(al.artistId),
-    });
-  }
+  const albumCount = Number(albumCountRow[0]?.c ?? 0);
 
-  const tracks = await db
-    .select({
-      id: lastfmTracks.id,
-      name: lastfmTracks.name,
-      artistId: lastfmTracks.artistId,
-    })
+  const trackCountRow = await db
+    .select({ c: sql<number>`count(*)` })
     .from(lastfmTracks)
     .where(eq(lastfmTracks.userId, 1));
-  for (const t of tracks) {
-    items.push({
-      domain: 'listening',
-      entityType: 'track',
-      entityId: String(t.id),
-      title: t.name,
-      subtitle: artistNameById.get(t.artistId),
-    });
+  const trackCount = Number(trackCountRow[0]?.c ?? 0);
+
+  const total = artistCount + albumCount + trackCount;
+  const items: SearchIndexItem[] = [];
+  let cursor = offset;
+  let remaining = limit;
+
+  // Segment 1: artists
+  if (cursor < artistCount && remaining > 0) {
+    const take = Math.min(remaining, artistCount - cursor);
+    const rows = await db
+      .select({ id: lastfmArtists.id, name: lastfmArtists.name })
+      .from(lastfmArtists)
+      .where(eq(lastfmArtists.userId, 1))
+      .orderBy(lastfmArtists.id)
+      .limit(take)
+      .offset(cursor);
+    for (const r of rows) {
+      items.push({
+        domain: 'listening',
+        entityType: 'artist',
+        entityId: String(r.id),
+        title: r.name,
+      });
+    }
+    cursor += rows.length;
+    remaining -= rows.length;
   }
 
-  return items;
+  // Segment 2: albums (with artist-name subtitle via JOIN)
+  if (cursor < artistCount + albumCount && remaining > 0) {
+    const segmentOffset = Math.max(0, cursor - artistCount);
+    const take = Math.min(remaining, artistCount + albumCount - cursor);
+    const rows = await db
+      .select({
+        id: lastfmAlbums.id,
+        name: lastfmAlbums.name,
+        artistName: lastfmArtists.name,
+      })
+      .from(lastfmAlbums)
+      .innerJoin(lastfmArtists, eq(lastfmAlbums.artistId, lastfmArtists.id))
+      .where(eq(lastfmAlbums.userId, 1))
+      .orderBy(lastfmAlbums.id)
+      .limit(take)
+      .offset(segmentOffset);
+    for (const r of rows) {
+      items.push({
+        domain: 'listening',
+        entityType: 'album',
+        entityId: String(r.id),
+        title: r.name,
+        subtitle: r.artistName ?? undefined,
+      });
+    }
+    cursor += rows.length;
+    remaining -= rows.length;
+  }
+
+  // Segment 3: tracks
+  if (cursor < total && remaining > 0) {
+    const segmentOffset = Math.max(0, cursor - artistCount - albumCount);
+    const take = Math.min(remaining, total - cursor);
+    const rows = await db
+      .select({
+        id: lastfmTracks.id,
+        name: lastfmTracks.name,
+        artistName: lastfmArtists.name,
+      })
+      .from(lastfmTracks)
+      .innerJoin(lastfmArtists, eq(lastfmTracks.artistId, lastfmArtists.id))
+      .where(eq(lastfmTracks.userId, 1))
+      .orderBy(lastfmTracks.id)
+      .limit(take)
+      .offset(segmentOffset);
+    for (const r of rows) {
+      items.push({
+        domain: 'listening',
+        entityType: 'track',
+        entityId: String(r.id),
+        title: r.name,
+        subtitle: r.artistName ?? undefined,
+      });
+    }
+  }
+
+  return { items, total };
 }
 
 async function buildRunning(


### PR DESCRIPTION
## Summary

Follow-up to the [album-attribution-repair project](docs/projects/album-attribution-repair/README.md). Phase 5 surfaced (didn't cause) a pre-existing limitation in the search reindex: the listening domain's 46K rows can't be indexed in one Worker CPU budget because `buildListening` loaded everything into memory.

After Phase 3's repair shipped, search for listening was stuck at ~100% artists / ~24% albums / 0% tracks because every chunked call rebuilt the full 46K-row array before slicing.

This PR makes `buildListening` segment-paginated at the SQL layer, matching the pattern `buildReading` already uses.

### What changes

- **`buildListening` now takes `(offset, limit)`** and returns `{ items, total }` directly. The combined stream is `artists [0, A) → albums [A, A+B) → tracks [A+B, A+B+C)`. Each segment uses real `LIMIT/OFFSET` against its source table.
- **Album / track subtitles** come from an `INNER JOIN` on `lastfm_artists` instead of a full artist-map preload. Memory stays bounded by chunk size.
- **`buildSearchItemsForDomain`** dispatches `listening` directly without `buildAllThenSlice`. The legacy helper stays for `watching` / `running` / `collecting` where the entity counts don't warrant pagination yet.
- **2 new tests**:
  - Chunked reindex with `chunk_size=1` proves the segment cursor crosses artist→album→track boundaries correctly
  - Joined-subtitle test confirms album and track rows get the right artist name

### Effect post-deploy

A single `POST /v1/admin/reindex-search {domains: ['listening']}` call should now complete all ~46K rows in one Worker call without timeout.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` green (1015/1015 — one unrelated flake in `watching.test.ts` passes on retry)
- [ ] After deploy: hit `/v1/admin/reindex-search` with `{domains:['listening']}` and confirm all three entity types reach their full counts in `search_index`