### PR TITLE
fix(images): chunk getImageAttachmentBatch under D1 100-param limit

### DIFF
--- a/src/lib/images.test.ts
+++ b/src/lib/images.test.ts
@@ -135,4 +135,40 @@ describe('getImageAttachmentBatch', () => {
     const img200 = result.get('200') as ImageAttachment;
     expect(img200.cdn_url).toContain('v=3');
   });
+
+  it('chunks queries to stay under the D1 100-parameter limit', async () => {
+    // 95 ids would be 2 fixed + 95 = 97 params (fine), but 99 ids tipped
+    // /watching/reviews over D1's 100-param cap. Pass 150 ids and assert
+    // the helper splits into multiple queries and merges all results.
+    const entityIds = Array.from({ length: 150 }, (_, i) => String(i));
+
+    mockWhere.mockImplementation((..._args) => {
+      const callIndex = mockWhere.mock.calls.length - 1;
+      // First chunk owns id "0", second chunk owns id "90".
+      const owned = callIndex === 0 ? '0' : '90';
+      return Promise.resolve([
+        {
+          entityId: owned,
+          r2Key: `watching/movies/${owned}/original.jpg`,
+          thumbhash: null,
+          dominantColor: null,
+          accentColor: null,
+          imageVersion: 1,
+        },
+      ]);
+    });
+
+    const result = await getImageAttachmentBatch(
+      mockDb,
+      'watching',
+      'movies',
+      entityIds
+    );
+
+    // 150 ids / 90 per chunk = 2 queries.
+    expect(mockSelect).toHaveBeenCalledTimes(2);
+    // Results from both chunks are merged.
+    expect(result.has('0')).toBe(true);
+    expect(result.has('90')).toBe(true);
+  });
 });

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -70,23 +70,34 @@ export async function getImageAttachmentBatch(
 ): Promise<Map<string, ImageAttachment>> {
   if (entityIds.length === 0) return new Map();
 
-  const rows = await db
-    .select({
-      entityId: images.entityId,
-      r2Key: images.r2Key,
-      thumbhash: images.thumbhash,
-      dominantColor: images.dominantColor,
-      accentColor: images.accentColor,
-      imageVersion: images.imageVersion,
-    })
-    .from(images)
-    .where(
-      and(
-        eq(images.domain, domain),
-        eq(images.entityType, entityType),
-        inArray(images.entityId, entityIds)
-      )
-    );
+  // D1 caps bound parameters at 100 per query. This query uses 2 fixed
+  // params (domain, entityType) plus one per entity id, so chunk the ids to
+  // stay safely under the limit regardless of how many entities are passed.
+  const CHUNK_SIZE = 90;
+  const selectChunk = (chunk: string[]) =>
+    db
+      .select({
+        entityId: images.entityId,
+        r2Key: images.r2Key,
+        thumbhash: images.thumbhash,
+        dominantColor: images.dominantColor,
+        accentColor: images.accentColor,
+        imageVersion: images.imageVersion,
+      })
+      .from(images)
+      .where(
+        and(
+          eq(images.domain, domain),
+          eq(images.entityType, entityType),
+          inArray(images.entityId, chunk)
+        )
+      );
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < entityIds.length; i += CHUNK_SIZE) {
+    chunks.push(entityIds.slice(i, i + CHUNK_SIZE));
+  }
+  const rows = (await Promise.all(chunks.map(selectChunk))).flat();
 
   const map = new Map<string, ImageAttachment>();
   for (const row of rows) {


### PR DESCRIPTION
## Problem

`pdugan.com/watching/reviews` showed **"No reviews found."** The portfolio fetches `/api/watching/reviews?limit=100`, which proxies to `api.rewind.rest/v1/watching/reviews`. That endpoint was returning **HTTP 500**, and the portfolio's `catch` renders an empty list on any error.

## Root cause

`getImageAttachmentBatch` (`src/lib/images.ts`) builds a single query:

```sql
WHERE domain = ? AND entityType = ? AND entityId IN (?, ?, …)
```

Bound-parameter count is `2 + entityIds.length`. **Cloudflare D1 caps bound parameters at 100 per query.**

The reviews total reached **99 movies**. The portfolio always requests `limit=100`, so the handler returns all 99 IDs → `2 + 99 = 101` params → D1 throws → 500. Verified on the live API, the boundary is exact:

| IDs returned | params | result |
|---|---|---|
| 98 | 100 | 200 ✅ |
| 99 | 101 | 500 ❌ |

A latent bug, not a regression — adding the 99th reviewed movie tipped it over.

## Fix

Chunk `entityIds` (90 per query, run in parallel, merge results) so no query exceeds the limit regardless of caller. Also closes the same latent bug for the `attending` routes, which pass larger ID lists.

- `src/lib/images.ts` — chunked batch query
- `src/lib/images.test.ts` — regression test (150 IDs → 2 queries, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)