### PR TITLE
fix(auth): require admin scope on domain-scoped admin routes

### DIFF
--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -164,3 +164,64 @@ describe('auth middleware', () => {
     });
   });
 });
+
+// Domain-scoped admin routes live at /v1/<domain>/admin/* rather than
+// /v1/admin/*, so the global gate in index.ts does not catch them. Each
+// domain router must guard its own /admin/* (listening, watching, reading).
+// A read key must never be able to reach these write/maintenance endpoints.
+describe('domain-scoped admin route gating', () => {
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(() => {
+    clearAuthCache();
+    resetRateLimitWindows();
+  });
+
+  const cases: Array<{ method: string; path: string; body?: unknown }> = [
+    { method: 'POST', path: '/v1/watching/admin/movies', body: { title: 'x' } },
+    { method: 'PUT', path: '/v1/watching/admin/movies/1', body: { rating: 5 } },
+    { method: 'DELETE', path: '/v1/watching/admin/movies/1' },
+    { method: 'POST', path: '/v1/listening/admin/filters', body: {} },
+    { method: 'GET', path: '/v1/listening/admin/filters' },
+    { method: 'DELETE', path: '/v1/listening/admin/filters/1' },
+  ];
+
+  for (const { method, path, body } of cases) {
+    it(`rejects a read key with 403 on ${method} ${path}`, async () => {
+      const readToken = await createTestApiKey({
+        scope: 'read',
+        name: `read-${method}-${path.replace(/\W+/g, '-')}`,
+      });
+      const res = await SELF.fetch(`http://localhost${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${readToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it(`does not return 403 for an admin key on ${method} ${path}`, async () => {
+      const adminToken = await createTestApiKey({
+        scope: 'admin',
+        name: `admin-${method}-${path.replace(/\W+/g, '-')}`,
+      });
+      const res = await SELF.fetch(`http://localhost${path}`, {
+        method,
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+      // Admin scope passes auth; status reflects the handler (e.g. 400/404),
+      // never an authorization rejection.
+      expect(res.status).not.toBe(403);
+      expect(res.status).not.toBe(401);
+    });
+  }
+});

--- a/src/routes/listening.ts
+++ b/src/routes/listening.ts
@@ -15,6 +15,7 @@ import {
   lastfmYearlyStats,
 } from '../db/schema/lastfm.js';
 import { setCache } from '../lib/cache.js';
+import { requireAuth } from '../lib/auth.js';
 import { DateFilterQuery, buildDateCondition } from '../lib/date-filters.js';
 import { notFound, badRequest, serverError } from '../lib/errors.js';
 import { getImageAttachment, getImageAttachmentBatch } from '../lib/images.js';
@@ -3805,6 +3806,11 @@ async function aggregateGenres(
 
 // POST /v1/admin/sync/listening -- moved to admin-sync.ts
 // Old path /v1/listening/admin/sync redirects via admin-sync.ts
+
+// All listening admin routes require an admin key. These live at
+// /v1/listening/admin/* (not /v1/admin/*), so the global gate in index.ts
+// does not catch them -- guard them here, as reading.ts does.
+listening.use('/admin/*', requireAuth('admin'));
 
 // GET /v1/admin/listening/filters
 listening.openapi(listFiltersRoute, async (c) => {

--- a/src/routes/watching.ts
+++ b/src/routes/watching.ts
@@ -2,6 +2,7 @@ import { createRoute, z } from '@hono/zod-openapi';
 import { eq, sql, desc, asc, and, count } from 'drizzle-orm';
 import { createDb } from '../db/client.js';
 import { setCache } from '../lib/cache.js';
+import { requireAuth } from '../lib/auth.js';
 import { DateFilterQuery, buildDateCondition } from '../lib/date-filters.js';
 import { notFound, badRequest } from '../lib/errors.js';
 import {
@@ -2252,6 +2253,11 @@ watching.openapi(yearInReviewRoute, async (c) => {
 });
 
 // ─── Admin: Manual movie entry ───────────────────────────────────────
+
+// All watching admin routes require an admin key. These live at
+// /v1/watching/admin/* (not /v1/admin/*), so the global gate in index.ts
+// does not catch them -- guard them here, as reading.ts does.
+watching.use('/admin/*', requireAuth('admin'));
 
 watching.openapi(adminCreateMovieRoute, async (c) => {
   const db = createDb(c.env.DB);


### PR DESCRIPTION
## Summary

The global auth gate in `index.ts` only admin-gates paths under `/v1/admin/`. The listening and watching admin write routes are mounted at `/v1/listening/admin/*` and `/v1/watching/admin/*`, so they fell through to **read-key** auth.

Net effect: a **read key** (`rw_live_`) could create/delete watch events, create/delete listening filters, and trigger backfills — operations that should require an admin key.

## Fix

Add the router-level `requireAuth('admin')` guard to the `listening` and `watching` routers, matching the guard `reading.ts` already has. (`collecting`/`images` mount at `/`, so their `/admin/...` routes resolve under `/v1/admin/` and were already gated.)

## Tests

New regression suite in `auth.test.ts` covering all six routes: a read key now gets `403`, an admin key does not.

## Deploy note

Behavior change: any caller using a **read key** against these routes will start getting `403` after deploy. Internal automation should use an admin key.