### PR TITLE
fix(images): process Letterboxd-only movie posters on sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7468,9 +7468,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/src/routes/admin-sync.ts
+++ b/src/routes/admin-sync.ts
@@ -20,7 +20,10 @@ import { syncLetterboxd } from '../services/letterboxd/sync.js';
 import { syncCollecting } from '../services/discogs/sync.js';
 import { syncTraktCollection } from '../services/trakt/sync.js';
 import { syncReading } from '../services/instapaper/sync.js';
-import { processReadingImages } from '../services/images/sync-images.js';
+import {
+  processReadingImages,
+  processWatchingImages,
+} from '../services/images/sync-images.js';
 import { backfillAttending } from '../services/attending/backfill.js';
 import { getGoogleAccessToken } from '../services/google/auth.js';
 import { googleTokens } from '../db/schema/google.js';
@@ -243,6 +246,15 @@ adminSync.openapi(syncWatchingRoute, async (c) => {
   try {
     if (source === 'letterboxd') {
       const result = await syncLetterboxd(db, c.env);
+      // Fetch posters for any newly-added movies in the background. The cron
+      // path dedups against the Plex run; a manual sync should always process.
+      c.executionCtx.waitUntil(
+        processWatchingImages(db, c.env).catch((err) =>
+          console.log(
+            `[ERROR] Watching image processing failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        )
+      );
       return c.json({
         success: true as const,
         source: 'letterboxd' as const,
@@ -251,6 +263,13 @@ adminSync.openapi(syncWatchingRoute, async (c) => {
       });
     } else {
       const result = await syncWatching(db, c.env);
+      c.executionCtx.waitUntil(
+        processWatchingImages(db, c.env).catch((err) =>
+          console.log(
+            `[ERROR] Watching image processing failed: ${err instanceof Error ? err.message : String(err)}`
+          )
+        )
+      );
       return c.json({
         success: true as const,
         source: 'plex' as const,

--- a/src/services/images/should-skip-watching-images.test.ts
+++ b/src/services/images/should-skip-watching-images.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { env } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/d1';
+import { setupTestDb } from '../../test-helpers.js';
+import { syncRuns } from '../../db/schema/system.js';
+import { shouldSkipWatchingImages } from './sync-images.js';
+
+/**
+ * Regression coverage for the Letterboxd-cron skip bug: shouldSkipWatchingImages
+ * must dedup only against the Plex daily cron (syncType 'plex_library'), not the
+ * Letterboxd sync's own domain='watching' completed run. A domain-only match
+ * meant the Letterboxd cron always skipped poster fetching, leaving
+ * Letterboxd-only movies without images until the next Plex cron.
+ */
+describe('shouldSkipWatchingImages', () => {
+  beforeEach(async () => {
+    await setupTestDb();
+    await env.DB.exec('DELETE FROM sync_runs');
+  });
+
+  const db = () => drizzle(env.DB);
+
+  async function insertRun(syncType: string, completedAt: string | null) {
+    await db()
+      .insert(syncRuns)
+      .values({
+        domain: 'watching',
+        syncType,
+        status: completedAt ? 'completed' : 'running',
+        startedAt: completedAt ?? new Date().toISOString(),
+        completedAt: completedAt ?? undefined,
+      });
+  }
+
+  it('does not skip when only a recent Letterboxd run exists', async () => {
+    await insertRun('letterboxd_rss', new Date().toISOString());
+    expect(await shouldSkipWatchingImages(db())).toBe(false);
+  });
+
+  it('skips when a recent Plex run exists', async () => {
+    await insertRun('plex_library', new Date().toISOString());
+    expect(await shouldSkipWatchingImages(db())).toBe(true);
+  });
+
+  it('does not skip when the Plex run is older than the 6h window', async () => {
+    const sevenHoursAgo = new Date(
+      Date.now() - 7 * 60 * 60 * 1000
+    ).toISOString();
+    await insertRun('plex_library', sevenHoursAgo);
+    expect(await shouldSkipWatchingImages(db())).toBe(false);
+  });
+
+  it('does not skip on a still-running (incomplete) Plex run', async () => {
+    await insertRun('plex_library', null);
+    expect(await shouldSkipWatchingImages(db())).toBe(false);
+  });
+});

--- a/src/services/images/sync-images.ts
+++ b/src/services/images/sync-images.ts
@@ -593,6 +593,14 @@ const IMAGE_SYNC_DEDUP_HOURS = 6;
 /**
  * Check if watching image processing was already run recently (within 6 hours)
  * by the Plex daily cron. If so, the Letterboxd cron can skip it.
+ *
+ * Must filter to syncType 'plex_library' — the Letterboxd sync writes its own
+ * domain='watching' completed run (syncType 'letterboxd_rss') immediately
+ * before this check runs, so a domain-only match would always see that run and
+ * skip image processing on every Letterboxd cron. That would leave
+ * Letterboxd-only movies (theatrical films never on Plex) without posters until
+ * the next daily Plex cron. processWatchingImages is only ever chained off the
+ * Plex cron, so 'plex_library' is the run we actually want to dedup against.
  */
 export async function shouldSkipWatchingImages(db: Database): Promise<boolean> {
   const cutoff = new Date(
@@ -605,6 +613,7 @@ export async function shouldSkipWatchingImages(db: Database): Promise<boolean> {
     .where(
       and(
         eq(syncRuns.domain, 'watching'),
+        eq(syncRuns.syncType, 'plex_library'),
         eq(syncRuns.status, 'completed'),
         sql`${syncRuns.completedAt} >= ${cutoff}`
       )


### PR DESCRIPTION
## Problem

Letterboxd-only movies (theatrical films logged on Letterboxd but never on Plex) were getting `image: null` and showing no poster. Surfaced by a recent watch: **Backrooms** had no poster.

## Root cause

The Letterboxd cron's poster-fetching step was silently skipping on every run:

- `shouldSkipWatchingImages()` deduped against any completed `domain='watching'` sync within 6h.
- But `syncLetterboxd()` writes its **own** `domain='watching'` completed run (`syncType: 'letterboxd_rss'`) immediately before the check.
- So the check always matched → `processWatchingImages` was effectively dead code on the Letterboxd path.

Letterboxd-only movies only got posters from the next daily 3:30 UTC Plex cron (which runs `processWatchingImages` unconditionally).

## Fix

- Scope `shouldSkipWatchingImages` to `syncType = 'plex_library'` — the only path that chains `processWatchingImages`. The 0/12/18 UTC Letterboxd crons now fetch posters for new movies immediately; only the 6:00 run skips (Plex just ran at 3:30).
- Run `processWatchingImages` from `POST /v1/admin/sync/watching` (both sources) via `waitUntil`, so a manual re-sync fetches posters on demand — mirrors the reading route. Previously the manual route never processed images.
- Add D1-backed regression coverage for the skip logic.

## Verification

- New test `should-skip-watching-images.test.ts` fails with the fix reverted, passes with it.
- typecheck clean, ESLint clean, Prettier clean.
- Full images suite (125 tests) + admin-sync suite (5 tests) green.