### PR TITLE
fix(mcp-server): bump hono and qs to patch runtime CVEs

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1309,9 +1309,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1967,9 +1967,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
Refreshes the `mcp-server` lockfile to pull patched transitive versions. Both packages arrive via `@modelcontextprotocol/sdk` and the patched releases fall within the existing semver ranges, so `package.json` is unchanged.

## Fixes
- **hono `4.12.18` → `4.12.23`** (≥ 4.12.21) — clears 4 medium CVEs in the deployed `mcp.rewind.rest` Worker, including JWT middleware accepting any `Authorization` scheme and `Set-Cookie` injection via unsanitized `sameSite`/`priority`.
- **qs `6.15.1` → `6.15.2`** — clears a remotely triggerable DoS in `qs.stringify` on null/undefined entries in comma-format arrays.

## Verification
- `npm audit` in `mcp-server` now reports **0 vulnerabilities**.
- All 162 mcp-server tests pass.

These were the only open Dependabot alerts touching a deployed runtime surface. The production API Worker's open alerts are all dev-scope; `docs-site` (build-time) and the vitest major bump are tracked for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)