### PR TITLE
ci(mcp-server): regenerate web bundles on build, publish, and deploy

### DIFF
--- a/.github/workflows/mcp-server.yml
+++ b/.github/workflows/mcp-server.yml
@@ -35,6 +35,7 @@ jobs:
           cache-dependency-path: mcp-server/package-lock.json
 
       - run: npm ci
+      - run: npm run build:web
       - run: npm run build
       - run: npm test
 
@@ -86,6 +87,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build web bundles
+        run: npm run build:web
+
       - name: Build
         run: npm run build
 
@@ -123,6 +127,9 @@ jobs:
           cache-dependency-path: mcp-server/package-lock.json
 
       - run: npm ci
+
+      - name: Build web bundles
+        run: npm run build:web
 
       - name: Deploy to Cloudflare Workers
         run: npx wrangler deploy


### PR DESCRIPTION
## Problem
`mcp-server/src/ui-bundles.ts` is an auto-generated artifact — `scripts/inline-bundles.mjs` bundles `web/*.html` (React via Vite + singlefile) into inlined HTML string exports. It's committed to the repo, but **`build:web` runs nowhere in CI**. So:

- The deployed Worker (`npx wrangler deploy`) and the npm package (`npm run build` → tsc) both ship whatever bytes are *committed*, not a fresh build from source.
- As the lockfile floats, the committed bundle silently drifts from what the toolchain now produces (observed this session: committed `5e738a…` vs a clean rebuild `dc149f…`, with `web/` source byte-identical — pure toolchain churn).
- A broken web component would never fail CI, since nothing exercises the generator.

## Change
Run `npm run build:web` (~0.3s) before the relevant steps in all three jobs:

| Job | Added before | Effect |
|---|---|---|
| Build & Verify | `npm run build` | Exercises generation on every push/PR (catches broken components); tsc + `npm pack --dry-run` reflect fresh output |
| Publish to npm | `npm run build` | npm package ships bundles built from current source |
| Deploy MCP Worker | `npx wrangler deploy` | Worker ships bundles built from current source |

The committed `src/ui-bundles.ts` is now just a fallback for local `tsc`; CI no longer depends on it being current, so the drift class is gone.

## Verification
- `npm run build:web` runs clean locally (10 entries, ~0.3s).
- Workflow YAML passes `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)