### PR TITLE
fix(listening): filter audiobooks out of now-playing

### DIFF
--- a/migrations/0041_add_pynchon_audiobook_filter.sql
+++ b/migrations/0041_add_pynchon_audiobook_filter.sql
@@ -1,0 +1,22 @@
+-- Add Thomas Pynchon as an audiobook artist filter.
+-- Plex scrobbled the "Inherent Vice" audiobook to Last.fm (artist = author),
+-- and it surfaced as "now playing". Pynchon's Last.fm tags are literature/
+-- novel rather than "audiobook", so the broadened tag heuristic now catches
+-- authors like him going forward; this explicit artist rule covers the
+-- existing data immediately and acts as a precise override.
+INSERT INTO lastfm_filters (filter_type, pattern, scope, reason, user_id, created_at)
+VALUES ('audiobook', 'thomas pynchon', 'artist', 'Author - Inherent Vice and other audiobooks', 1, datetime('now'));
+
+-- Mark existing Thomas Pynchon artist, albums, and tracks as filtered.
+UPDATE lastfm_artists SET is_filtered = 1
+WHERE LOWER(name) = 'thomas pynchon';
+
+UPDATE lastfm_albums SET is_filtered = 1
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'thomas pynchon'
+);
+
+UPDATE lastfm_tracks SET is_filtered = 1
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'thomas pynchon'
+);

--- a/src/routes/listening.ts
+++ b/src/routes/listening.ts
@@ -22,6 +22,7 @@ import { getImageAttachment, getImageAttachmentBatch } from '../lib/images.js';
 import { images } from '../db/schema/system.js';
 import { LastfmClient } from '../services/lastfm/client.js';
 import type { LastfmPeriod } from '../services/lastfm/client.js';
+import { loadFilters, isFiltered } from '../services/lastfm/filters.js';
 import {
   enrichArtistBio,
   type SimilarArtistEntry,
@@ -1684,26 +1685,68 @@ listening.openapi(nowPlayingRoute, async (c) => {
   const db = createDb(c.env.DB);
 
   try {
-    const response = await client.getRecentTracks({ limit: 1 });
+    // now-playing reads live from Last.fm (the only listening endpoint that
+    // does). Every other endpoint excludes audiobooks/holiday music via the
+    // synced is_filtered columns, so we must apply the same filtering here --
+    // otherwise a stray scrobble (e.g. Plex scrobbling an audiobook) surfaces
+    // as "now playing". Over-fetch so we can fall through to the most recent
+    // track that isn't filtered.
+    await loadFilters(db);
+    const response = await client.getRecentTracks({ limit: 20 });
     const tracks = response.recenttracks.track;
 
     if (!tracks || tracks.length === 0) {
       return c.json({ is_playing: false, track: null, scrobbled_at: null });
     }
 
-    const latestTrack = tracks[0];
-    const isPlaying = latestTrack['@attr']?.nowplaying === 'true';
+    // Walk newest-to-oldest and pick the first track that isn't filtered.
+    // Check both the live filter rules (artist/album/track patterns -- catches
+    // an author blacklist before a sync flags the row) and the synced
+    // is_filtered flag on the artist (catches tag-detected audiobooks).
+    let latestTrack: (typeof tracks)[number] | undefined;
+    let artist:
+      | { id: number; name: string; appleMusicUrl: string | null }
+      | undefined;
 
-    // Look up artist in DB for ID
-    const [artist] = await db
-      .select({
-        id: lastfmArtists.id,
-        name: lastfmArtists.name,
-        appleMusicUrl: lastfmArtists.appleMusicUrl,
-      })
-      .from(lastfmArtists)
-      .where(eq(lastfmArtists.name, latestTrack.artist['#text']))
-      .limit(1);
+    for (const candidate of tracks) {
+      const artistName = candidate.artist['#text'];
+      if (
+        isFiltered({
+          artistName,
+          albumName: candidate.album?.['#text'] || undefined,
+          trackName: candidate.name,
+        })
+      ) {
+        continue;
+      }
+
+      const [row] = await db
+        .select({
+          id: lastfmArtists.id,
+          name: lastfmArtists.name,
+          appleMusicUrl: lastfmArtists.appleMusicUrl,
+          isFiltered: lastfmArtists.isFiltered,
+        })
+        .from(lastfmArtists)
+        .where(eq(lastfmArtists.name, artistName))
+        .limit(1);
+
+      if (row?.isFiltered === 1) {
+        continue;
+      }
+
+      latestTrack = candidate;
+      artist = row
+        ? { id: row.id, name: row.name, appleMusicUrl: row.appleMusicUrl }
+        : undefined;
+      break;
+    }
+
+    if (!latestTrack) {
+      return c.json({ is_playing: false, track: null, scrobbled_at: null });
+    }
+
+    const isPlaying = latestTrack['@attr']?.nowplaying === 'true';
 
     // Resolve track + album via the stored track.album_id link. Mirrors the
     // /recent endpoint's join shape so attribution stays consistent across

--- a/src/services/lastfm/filters.test.ts
+++ b/src/services/lastfm/filters.test.ts
@@ -251,4 +251,35 @@ describe('hasAudiobookTags', () => {
   it('returns false for empty tags', () => {
     expect(hasAudiobookTags([])).toBe(false);
   });
+
+  it('detects book authors from literary tags (Thomas Pynchon case)', () => {
+    // Real Last.fm top tags for Thomas Pynchon: no "audiobook"/"spoken word"
+    // tag exists, but "literature"/"novel" clearly mark an author whose
+    // "music" is an audiobook.
+    expect(
+      hasAudiobookTags([
+        { name: 'postmodern', count: 100 },
+        { name: 'literature', count: 100 },
+        { name: 'adventure', count: 66 },
+        { name: 'audio', count: 66 },
+        { name: 'novel', count: 33 },
+      ])
+    ).toBe(true);
+  });
+
+  it('detects fiction/author literary tags', () => {
+    expect(hasAudiobookTags([{ name: 'fiction', count: 50 }])).toBe(true);
+    expect(hasAudiobookTags([{ name: 'Author', count: 40 }])).toBe(true);
+    expect(hasAudiobookTags([{ name: 'poetry', count: 30 }])).toBe(true);
+  });
+
+  it('ignores a weak/stray literary tag on a music artist', () => {
+    expect(
+      hasAudiobookTags([
+        { name: 'rock', count: 100 },
+        { name: 'alternative', count: 80 },
+        { name: 'literature', count: 8 },
+      ])
+    ).toBe(false);
+  });
 });

--- a/src/services/lastfm/filters.ts
+++ b/src/services/lastfm/filters.ts
@@ -134,11 +134,31 @@ const AUDIOBOOK_TAGS = new Set([
   'hörbuch',
   'audio book',
   'audio books',
+  // Literary/written-word tags. Book authors (e.g. Thomas Pynchon, Robert A.
+  // Caro) are rarely tagged "audiobook" on Last.fm, but the crowd reliably
+  // tags them as literature/fiction/etc. Their "music" is an audiobook
+  // scrobbled by Plex/Audiobookshelf, so treat these as audiobook signals.
+  'literature',
+  'literary',
+  'novel',
+  'novels',
+  'fiction',
+  'non-fiction',
+  'nonfiction',
+  'author',
+  'authors',
+  'writer',
+  'writers',
+  'poetry',
+  'poet',
+  'short stories',
+  'essays',
 ]);
 
 /**
  * Check if raw Last.fm tags indicate an audiobook/spoken-word artist.
- * Returns true if any tag with sufficient weight matches.
+ * Returns true if any tag with sufficient weight matches. The weight floor
+ * (25) keeps a stray low-confidence tag on a music artist from tripping it.
  */
 export function hasAudiobookTags(
   tags: { name: string; count: number }[]


### PR DESCRIPTION
## Problem

The site's "now playing" flipped to *Inherent Vice* by Thomas Pynchon — an audiobook. Two compounding causes:

1. **`/v1/listening/now-playing` applied zero filtering.** It read live from Last.fm and returned the most recent scrobble verbatim. Every *other* listening endpoint excludes audiobooks/holiday music via the synced `is_filtered` columns; now-playing didn't. So a stray scrobble (Plex scrobbling an audiobook as `artist = author`) surfaced as now-playing.
2. **Pynchon wasn't detected as an audiobook.** The crowd-tag heuristic only matched literal `audiobook`/`spoken word` tags. Pynchon's Last.fm tags are `literature`/`novel`/`postmodern`, so he slipped through — and would leak into `/recent` and top lists too.

## Changes

- **`now-playing` filters like the rest of the site.** Loads filter rules, over-fetches recent tracks, and returns the most recent track that isn't filtered — checking both live filter rules and the synced `is_filtered` flag. Falls through past audiobooks to the last real listen.
- **Broadened audiobook detection** (`hasAudiobookTags`) to recognize literary tags (`literature`, `novel`, `fiction`, `author`, `writers`, `poetry`, …) on top of the existing audiobook/spoken-word tags, with the weight floor kept to avoid misflagging music artists. Book authors now get auto-flagged at sync time instead of needing a hardcoded list.
- **Explicit Pynchon override** (migration `0041`): adds a `thomas pynchon` audiobook rule and back-fills `is_filtered` on his artist/albums/tracks, mirroring the existing Robert A. Caro migration.

## Verification

- New unit tests for the broadened tag heuristic (Pynchon tag profile + false-positive guard).
- Full suite green (1028 tests), typecheck + lint + prettier clean.
- Verified end-to-end against a local dev server hitting live Last.fm: now-playing returns Olivia Rodrigo and skips the Pynchon audiobook.