### PR TITLE
ci: align npm with the version Dependabot authors lockfiles with

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,14 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
+
+      # Dependabot authors lockfiles with npm 11, which omits nested
+      # auto-installed peer entries that the npm 10 bundled with Node 22
+      # requires -- so `npm ci` fails with "Missing: <pkg> from lock file"
+      # on freshly rebased Dependabot PRs. Align CI with the authoring tool.
+      - run: npm install -g npm@11
 
       - run: npm ci
 
@@ -50,8 +56,14 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
+
+      # Dependabot authors lockfiles with npm 11, which omits nested
+      # auto-installed peer entries that the npm 10 bundled with Node 22
+      # requires -- so `npm ci` fails with "Missing: <pkg> from lock file"
+      # on freshly rebased Dependabot PRs. Align CI with the authoring tool.
+      - run: npm install -g npm@11
 
       - run: npm ci
 
@@ -66,7 +78,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Check MCP tool reference is up to date
         run: npx tsx scripts/gen-mcp-reference.ts --check
@@ -83,8 +95,14 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
+
+      # Dependabot authors lockfiles with npm 11, which omits nested
+      # auto-installed peer entries that the npm 10 bundled with Node 22
+      # requires -- so `npm ci` fails with "Missing: <pkg> from lock file"
+      # on freshly rebased Dependabot PRs. Align CI with the authoring tool.
+      - run: npm install -g npm@11
 
       - run: npm ci
 
@@ -102,8 +120,14 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
+
+      # Dependabot authors lockfiles with npm 11, which omits nested
+      # auto-installed peer entries that the npm 10 bundled with Node 22
+      # requires -- so `npm ci` fails with "Missing: <pkg> from lock file"
+      # on freshly rebased Dependabot PRs. Align CI with the authoring tool.
+      - run: npm install -g npm@11
 
       - run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version: '22'
+          cache: 'npm'
 
       # Dependabot authors lockfiles with npm 11, which omits nested
       # auto-installed peer entries that the npm 10 bundled with Node 22
@@ -56,8 +56,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version: '22'
+          cache: 'npm'
 
       # Dependabot authors lockfiles with npm 11, which omits nested
       # auto-installed peer entries that the npm 10 bundled with Node 22
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: '22'
 
       - name: Check MCP tool reference is up to date
         run: npx tsx scripts/gen-mcp-reference.ts --check
@@ -95,8 +95,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version: '22'
+          cache: 'npm'
 
       # Dependabot authors lockfiles with npm 11, which omits nested
       # auto-installed peer entries that the npm 10 bundled with Node 22
@@ -120,8 +120,8 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
-          cache: "npm"
+          node-version: '22'
+          cache: 'npm'
 
       # Dependabot authors lockfiles with npm 11, which omits nested
       # auto-installed peer entries that the npm 10 bundled with Node 22


### PR DESCRIPTION
Fixes the fresh `npm ci` failures on the three cloudflare-group Dependabot PRs (#166/#167/#168):

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync
npm error Missing: @cloudflare/workers-types@5.20260721.1 from lock file
```

## Root cause — proven in a sibling repo, same mechanism here

Dependabot authors lockfiles with **npm 11**. Node 22's bundled npm is **10.x**, which requires nested auto-installed peer entries that npm 11 legitimately omits. The same lockfile installs clean under npm 11 and fails under npm 10 — verified byte-for-byte in pdugan20/libby-downloader#114 (authoring with npm 11 then running `npx npm@10.9.8 ci` reproduces the exact error; npm 11 installs clean).

These failures are **fresh** (13:55 today, post-rebase onto green main) — not the stale pre-fix results the other rewind PRs carried.

## Fix

`npm install -g npm@11` before each of the 4 `npm ci` invocations, so CI validates lockfiles with the same tool that writes them. Toolchain-policy note: CI no longer uses the npm bundled with Node LTS — same call already made in libby-downloader.

YAML validated (6 jobs parse), prettier-clean (this repo lints workflow files — learned that on #169).