### PR TITLE
fix(listening): keep audiobooks out of public activity

### DIFF
--- a/migrations/0042_filter_odyssey_audiobook.sql
+++ b/migrations/0042_filter_odyssey_audiobook.sql
@@ -1,0 +1,51 @@
+-- Filter the Odyssey audiobook that Plex scrobbles to Last.fm under a
+-- composite author/translator artist name. Last.fm has no tag data for this
+-- artist, so tag-based audiobook detection cannot classify it.
+INSERT INTO lastfm_filters (filter_type, pattern, scope, reason, user_id, created_at)
+VALUES ('audiobook', 'homer, robert fagles', 'artist', 'Author and translator - The Odyssey audiobook', 1, datetime('now'));
+
+UPDATE lastfm_artists SET is_filtered = 1
+WHERE LOWER(name) = 'homer, robert fagles';
+
+UPDATE lastfm_albums SET is_filtered = 1
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'homer, robert fagles'
+);
+
+UPDATE lastfm_tracks SET is_filtered = 1
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'homer, robert fagles'
+);
+
+-- Remove side effects emitted before the artist was recognized as filtered.
+DELETE FROM activity_feed
+WHERE domain = 'listening'
+  AND (
+    source_id IN (
+      SELECT 'artist:' || id FROM lastfm_artists
+      WHERE LOWER(name) = 'homer, robert fagles'
+    )
+    OR source_id IN (
+      SELECT 'album:' || id FROM lastfm_albums
+      WHERE artist_id IN (
+        SELECT id FROM lastfm_artists
+        WHERE LOWER(name) = 'homer, robert fagles'
+      )
+    )
+  );
+
+DELETE FROM search_index
+WHERE domain = 'listening'
+  AND (
+    (entity_type = 'artist' AND entity_id IN (
+      SELECT CAST(id AS TEXT) FROM lastfm_artists
+      WHERE LOWER(name) = 'homer, robert fagles'
+    ))
+    OR (entity_type = 'album' AND entity_id IN (
+      SELECT CAST(id AS TEXT) FROM lastfm_albums
+      WHERE artist_id IN (
+        SELECT id FROM lastfm_artists
+        WHERE LOWER(name) = 'homer, robert fagles'
+      )
+    ))
+  );

--- a/src/services/lastfm/filters.test.ts
+++ b/src/services/lastfm/filters.test.ts
@@ -142,6 +142,26 @@ describe('isAudiobook', () => {
     ).toBe(true);
   });
 
+  it('detects numbered audiobook chapters that repeat the album title', () => {
+    expect(
+      isAudiobook({
+        artistName: 'Homer, Robert Fagles',
+        albumName: 'The Odyssey',
+        trackName: '006 - The Odyssey (Fagles translation)',
+      })
+    ).toBe(true);
+  });
+
+  it('does not flag numbered music tracks without the album title', () => {
+    expect(
+      isAudiobook({
+        artistName: 'Bon Iver',
+        albumName: '22, a Million',
+        trackName: '715 - CR∑∑KS',
+      })
+    ).toBe(false);
+  });
+
   it('does not flag regular music', () => {
     expect(
       isAudiobook({

--- a/src/services/lastfm/filters.ts
+++ b/src/services/lastfm/filters.ts
@@ -85,11 +85,29 @@ export function isHolidayMusic(item: FilterableItem): boolean {
   return false;
 }
 
+export function hasNumberedAudiobookSignature(item: FilterableItem): boolean {
+  const albumLower = (item.albumName ?? '').toLowerCase();
+  const trackLower = (item.trackName ?? '').toLowerCase();
+  const trackName = item.trackName ?? '';
+
+  // Audiobooks scrobbled by Plex commonly use a zero-padded file sequence
+  // followed by the book title (for example, "006 - The Odyssey ..."). The
+  // album-title check keeps this narrow enough to preserve legitimate numbered
+  // songs such as Bon Iver's "715 - CR∑∑KS".
+  return (
+    albumLower.length >= 5 &&
+    /^\d{3}\s+-\s+/.test(trackName) &&
+    trackLower.includes(albumLower)
+  );
+}
+
 export function isAudiobook(item: FilterableItem): boolean {
   const artistLower = item.artistName.toLowerCase();
   const albumLower = (item.albumName ?? '').toLowerCase();
   const trackLower = (item.trackName ?? '').toLowerCase();
   const trackName = item.trackName ?? '';
+
+  if (hasNumberedAudiobookSignature(item)) return true;
 
   for (const rule of getFilters()) {
     if (rule.filterType !== 'audiobook') continue;

--- a/src/services/lastfm/sync.test.ts
+++ b/src/services/lastfm/sync.test.ts
@@ -10,18 +10,74 @@ import {
 } from '../../db/schema/lastfm.js';
 import { setupTestDb } from '../../test-helpers.js';
 import {
+  syncRecentScrobbles,
   syncListening,
   syncYearlyStats,
   upsertAlbum,
   upsertArtist,
 } from './sync.js';
 import { VARIOUS_ARTISTS_MBID } from './constants.js';
+import type { LastfmClient } from './client.js';
 import { loadFilters } from './filters.js';
 import { eq } from 'drizzle-orm';
 
 describe('syncListening', () => {
   it('exports syncListening function', () => {
     expect(typeof syncListening).toBe('function');
+  });
+});
+
+describe('syncRecentScrobbles audiobook filtering', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  beforeEach(async () => {
+    db = createDb(env.DB);
+    await db.delete(lastfmYearlyStats);
+    await db.delete(lastfmScrobbles);
+    await db.delete(lastfmTracks);
+    await db.delete(lastfmAlbums);
+    await db.delete(lastfmArtists);
+    await loadFilters(db);
+  });
+
+  it('cascades a numbered audiobook signature and omits it from feed/search candidates', async () => {
+    const client = {
+      getRecentTracks: async () => ({
+        recenttracks: {
+          track: [
+            {
+              artist: { mbid: '', '#text': 'Homer, Emily Wilson' },
+              name: '001 - The Iliad (Wilson translation)',
+              mbid: '',
+              album: { mbid: '', '#text': 'The Iliad' },
+              url: 'https://last.fm/test/iliad',
+              date: { uts: '1785298519', '#text': '29 Jul 2026' },
+              image: [],
+            },
+          ],
+          '@attr': { totalPages: '1' },
+        },
+      }),
+      getArtistTopTags: async () => {
+        throw new Error('Artist not found');
+      },
+    } as unknown as LastfmClient;
+
+    const result = await syncRecentScrobbles(db, client);
+
+    const [artist] = await db.select().from(lastfmArtists);
+    const [album] = await db.select().from(lastfmAlbums);
+    const [track] = await db.select().from(lastfmTracks);
+
+    expect(artist.isFiltered).toBe(1);
+    expect(album.isFiltered).toBe(1);
+    expect(track.isFiltered).toBe(1);
+    expect(result.newArtists.size).toBe(0);
+    expect(result.newAlbums.size).toBe(0);
   });
 });
 

--- a/src/services/lastfm/sync.ts
+++ b/src/services/lastfm/sync.ts
@@ -16,7 +16,12 @@ import { syncRuns } from '../../db/schema/system.js';
 import { LastfmClient, LASTFM_PERIODS } from './client.js';
 import type { LastfmPeriod } from './client.js';
 import { normalizeScrobble } from './transforms.js';
-import { isFiltered, hasAudiobookTags, loadFilters } from './filters.js';
+import {
+  hasNumberedAudiobookSignature,
+  isFiltered,
+  hasAudiobookTags,
+  loadFilters,
+} from './filters.js';
 import { afterSync } from '../../lib/after-sync.js';
 import type { FeedItem, SearchItem } from '../../lib/after-sync.js';
 import { cleanArtistName } from '../images/sources/utils.js';
@@ -30,7 +35,7 @@ export async function upsertArtist(
   rawName: string,
   mbid: string | null,
   url?: string
-): Promise<{ id: number; isNew: boolean }> {
+): Promise<{ id: number; isNew: boolean; isFiltered: boolean }> {
   // Strip featured artist suffixes so "Gorillaz feat. IDLES" -> "Gorillaz"
   const name = cleanArtistName(rawName);
 
@@ -38,17 +43,17 @@ export async function upsertArtist(
   // anchors the canonical Various Artists row (seeded by migration 0038)
   // even if a scrobble's artist text drifts. Falls back to name match
   // for scrobbles Last.fm hasn't mbid-tagged yet.
-  let existing: { id: number } | undefined;
+  let existing: { id: number; isFiltered: number | null } | undefined;
   if (mbid) {
     [existing] = await db
-      .select({ id: lastfmArtists.id })
+      .select({ id: lastfmArtists.id, isFiltered: lastfmArtists.isFiltered })
       .from(lastfmArtists)
       .where(eq(lastfmArtists.mbid, mbid))
       .limit(1);
   }
   if (!existing) {
     [existing] = await db
-      .select({ id: lastfmArtists.id })
+      .select({ id: lastfmArtists.id, isFiltered: lastfmArtists.isFiltered })
       .from(lastfmArtists)
       .where(eq(lastfmArtists.name, name))
       .limit(1);
@@ -61,7 +66,11 @@ export async function upsertArtist(
         .set({ mbid, updatedAt: new Date().toISOString() })
         .where(eq(lastfmArtists.id, existing.id));
     }
-    return { id: existing.id, isNew: false };
+    return {
+      id: existing.id,
+      isNew: false,
+      isFiltered: existing.isFiltered === 1,
+    };
   }
 
   const filtered = isFiltered({ artistName: name }) ? 1 : 0;
@@ -75,7 +84,7 @@ export async function upsertArtist(
     })
     .returning({ id: lastfmArtists.id });
 
-  return { id: result[0].id, isNew: true };
+  return { id: result[0].id, isNew: true, isFiltered: filtered === 1 };
 }
 
 // Exported so the album-attribution-repair test suite can assert the
@@ -288,6 +297,15 @@ export async function syncRecentScrobbles(
         // Skip now-playing tracks (no timestamp)
         if (track.isNowPlaying || !track.scrobbledAt) continue;
 
+        const filterableTrack = {
+          artistName: track.artistName,
+          albumName: track.albumName,
+          trackName: track.trackName,
+        };
+        const matchesAudiobookSignature =
+          hasNumberedAudiobookSignature(filterableTrack);
+        let filteredItem = isFiltered(filterableTrack);
+
         const artist = await upsertArtist(
           db,
           track.artistName,
@@ -314,6 +332,7 @@ export async function syncRecentScrobbles(
         );
 
         // Tag new artists with genres from Last.fm
+        let tagFiltered = false;
         if (artist.isNew) {
           try {
             const tagResponse = await client.getArtistTopTags(track.artistName);
@@ -324,7 +343,7 @@ export async function syncRecentScrobbles(
             const { genre, normalizedTags } = resolveGenre(rawTags);
 
             // Auto-detect audiobook artists from Last.fm tags
-            const tagFiltered = hasAudiobookTags(rawTags) ? 1 : 0;
+            tagFiltered = hasAudiobookTags(rawTags);
 
             await db
               .update(lastfmArtists)
@@ -334,31 +353,50 @@ export async function syncRecentScrobbles(
                 ...(tagFiltered ? { isFiltered: 1 } : {}),
               })
               .where(eq(lastfmArtists.id, artist.id));
-
-            // Cascade filter to albums/tracks for this artist
-            if (tagFiltered) {
-              await db
-                .update(lastfmAlbums)
-                .set({ isFiltered: 1 })
-                .where(eq(lastfmAlbums.artistId, artist.id));
-              await db
-                .update(lastfmTracks)
-                .set({ isFiltered: 1 })
-                .where(eq(lastfmTracks.artistId, artist.id));
-              console.log(
-                `[SYNC] Auto-filtered audiobook artist from tags: ${track.artistName}`
-              );
-            }
           } catch {
             // Non-fatal -- artist still gets created, tags can be backfilled later
           }
         }
 
+        // Tag lookups can fail for author/narrator composite names. Fall back
+        // to the item-level audiobook signature and cascade the decision so
+        // every stored listening endpoint observes the same filter state.
+        const shouldCascadeAudiobookFilter =
+          artist.isFiltered || matchesAudiobookSignature || tagFiltered;
+        if (shouldCascadeAudiobookFilter) {
+          await db
+            .update(lastfmArtists)
+            .set({ isFiltered: 1 })
+            .where(eq(lastfmArtists.id, artist.id));
+          if (album) {
+            await db
+              .update(lastfmAlbums)
+              .set({ isFiltered: 1 })
+              .where(eq(lastfmAlbums.id, album.id));
+          }
+          await db
+            .update(lastfmTracks)
+            .set({ isFiltered: 1 })
+            .where(eq(lastfmTracks.id, trackId));
+          filteredItem = true;
+
+          if (!artist.isFiltered) {
+            console.log(
+              `[SYNC] Auto-filtered audiobook item: ${track.artistName} - ${track.trackName}`
+            );
+          }
+        }
+
         // Track new artists and albums for feed/search
-        if (artist.isNew && !newArtists.has(track.artistName)) {
+        if (
+          !filteredItem &&
+          artist.isNew &&
+          !newArtists.has(track.artistName)
+        ) {
           newArtists.set(track.artistName, String(artist.id));
         }
         if (
+          !filteredItem &&
           album?.isNew &&
           track.albumName &&
           !newAlbums.has(`${track.artistName}:${track.albumName}`)


### PR DESCRIPTION
## What changed

- recognize zero-padded audiobook chapter names that repeat the album title
- cascade high-confidence audiobook classification to the stored artist, album, and track
- suppress filtered listening discoveries from feed and search side effects
- add migration `0042` to filter the existing Odyssey data and remove its emitted feed/search records

## Root cause

Last.fm returned no tag data for the composite artist `Homer, Robert Fagles`. The sync treated the failed enrichment as non-fatal, then stored the artist, album, and tracks with `is_filtered = 0`. Both `/v1/listening/now-playing` and `/v1/listening/recent` therefore exposed the audiobook to the portfolio.

## Validation

- `npm test` — 97 files, 1,040 tests passed
- `npm run type-check`
- focused ESLint on changed TypeScript files
- `npm run build` — Wrangler dry-run succeeded
- pre-push type-check, full ESLint, and API/MCP snapshot checks passed
