### PR TITLE
docs: document shared project skill ownership

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,9 @@
+# Repository skills
+
+These are Rewind-specific workflows and remain **project-scoped**:
+
+- `media-search` performs read-only TMDb and Discogs lookups.
+- `add-media` adds physical media through Rewind's live admin API; the user's add request supplies the mutation intent, and ambiguous or large batches require confirmation as documented in the skill.
+- `changelog-writer` applies Rewind's Mintlify changelog format and voice.
+
+`.agents/skills` is the canonical source for Codex and Claude. Claude's `.claude/skills` entries are relative symlinks to these directories. These skills are maintained with Rewind because their endpoints, credentials, domain model, and documentation format are not general-purpose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,18 @@ npm run db:remote    # Apply migrations to remote D1
 npm run db:studio    # Open Drizzle Studio (local D1)
 npm run lint         # ESLint
 npm run format       # Prettier
-npm run lint:claude  # claudelint (validate Claude Code files)
+npm run lint:claude  # claudelint (validate agent instruction files)
 npm test             # Vitest
 ```
+
+## Agent configuration
+
+- `AGENTS.md` is the canonical cross-agent guide; `CLAUDE.md` is only a compatibility shim.
+- Repository skills live in `.agents/skills`. Claude consumes those same files through symlinks in
+  `.claude/skills`; do not maintain a second copy.
+- Keep domain procedures such as adding and finding media project-scoped. General design, delivery, review, and
+  hardening workflows come from the global agent-tooling setup.
+- See `.agents/skills/README.md` for the project inventory and mutation boundaries.
 
 ## Architecture Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Shared agent guidance
-
 @AGENTS.md


### PR DESCRIPTION
Documents the canonical project-skill inventory, Claude compatibility links, and mutation boundaries while keeping the already-merged shared skill layout intact. Verification: ClaudeLint and targeted Prettier checks.