### PR TITLE
fix(listening): reject Prologue audiobooks at ingestion

### DIFF
--- a/migrations/0043_filter_pirsig_audiobook.sql
+++ b/migrations/0043_filter_pirsig_audiobook.sql
@@ -1,0 +1,165 @@
+-- Permanently exclude the Prologue/Plex audiobook that arrived under its
+-- author and remove every public/listening-history side effect already made.
+INSERT INTO lastfm_filters (
+  filter_type,
+  pattern,
+  scope,
+  reason,
+  user_id,
+  created_at
+)
+SELECT
+  'audiobook',
+  'robert m. pirsig',
+  'artist',
+  'Author - Zen and the Art of Motorcycle Maintenance audiobook',
+  1,
+  datetime('now')
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM lastfm_filters
+  WHERE user_id = 1
+    AND filter_type = 'audiobook'
+    AND scope = 'artist'
+    AND LOWER(pattern) = 'robert m. pirsig'
+);
+
+UPDATE lastfm_artists
+SET is_filtered = 1
+WHERE LOWER(name) = 'robert m. pirsig';
+
+UPDATE lastfm_albums
+SET is_filtered = 1
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'robert m. pirsig'
+);
+
+UPDATE lastfm_tracks
+SET is_filtered = 1
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'robert m. pirsig'
+);
+
+DELETE FROM activity_feed
+WHERE domain = 'listening'
+  AND (
+    source_id IN (
+      SELECT 'artist:' || id
+      FROM lastfm_artists
+      WHERE LOWER(name) = 'robert m. pirsig'
+    )
+    OR source_id IN (
+      SELECT 'album:' || id
+      FROM lastfm_albums
+      WHERE artist_id IN (
+        SELECT id
+        FROM lastfm_artists
+        WHERE LOWER(name) = 'robert m. pirsig'
+      )
+    )
+  );
+
+DELETE FROM search_index
+WHERE domain = 'listening'
+  AND (
+    (entity_type = 'artist' AND entity_id IN (
+      SELECT CAST(id AS TEXT)
+      FROM lastfm_artists
+      WHERE LOWER(name) = 'robert m. pirsig'
+    ))
+    OR (entity_type = 'album' AND entity_id IN (
+      SELECT CAST(id AS TEXT)
+      FROM lastfm_albums
+      WHERE artist_id IN (
+        SELECT id
+        FROM lastfm_artists
+        WHERE LOWER(name) = 'robert m. pirsig'
+      )
+    ))
+  );
+
+DELETE FROM images
+WHERE domain = 'listening'
+  AND (
+    (entity_type = 'artists' AND entity_id IN (
+      SELECT CAST(id AS TEXT)
+      FROM lastfm_artists
+      WHERE LOWER(name) = 'robert m. pirsig'
+    ))
+    OR (entity_type = 'albums' AND entity_id IN (
+      SELECT CAST(id AS TEXT)
+      FROM lastfm_albums
+      WHERE artist_id IN (
+        SELECT id
+        FROM lastfm_artists
+        WHERE LOWER(name) = 'robert m. pirsig'
+      )
+    ))
+  );
+
+DELETE FROM lastfm_top_tracks
+WHERE track_id IN (
+  SELECT id
+  FROM lastfm_tracks
+  WHERE artist_id IN (
+    SELECT id FROM lastfm_artists WHERE LOWER(name) = 'robert m. pirsig'
+  )
+);
+
+DELETE FROM lastfm_top_albums
+WHERE album_id IN (
+  SELECT id
+  FROM lastfm_albums
+  WHERE artist_id IN (
+    SELECT id FROM lastfm_artists WHERE LOWER(name) = 'robert m. pirsig'
+  )
+);
+
+DELETE FROM lastfm_top_artists
+WHERE artist_id IN (
+  SELECT id FROM lastfm_artists WHERE LOWER(name) = 'robert m. pirsig'
+);
+
+DELETE FROM lastfm_scrobbles
+WHERE track_id IN (
+  SELECT id
+  FROM lastfm_tracks
+  WHERE artist_id IN (
+    SELECT id FROM lastfm_artists WHERE LOWER(name) = 'robert m. pirsig'
+  )
+);
+
+-- Keep the cached summary aligned immediately. The deployed full sync refreshes
+-- all monthly/yearly aggregates after the migration.
+UPDATE lastfm_user_stats
+SET
+  total_scrobbles = (
+    SELECT COUNT(*)
+    FROM lastfm_scrobbles s
+    JOIN lastfm_tracks t ON t.id = s.track_id
+    JOIN lastfm_artists a ON a.id = t.artist_id
+    WHERE t.is_filtered = 0 AND a.is_filtered = 0
+  ),
+  unique_artists = (
+    SELECT COUNT(DISTINCT t.artist_id)
+    FROM lastfm_scrobbles s
+    JOIN lastfm_tracks t ON t.id = s.track_id
+    JOIN lastfm_artists a ON a.id = t.artist_id
+    WHERE t.is_filtered = 0 AND a.is_filtered = 0
+  ),
+  unique_albums = (
+    SELECT COUNT(DISTINCT t.album_id)
+    FROM lastfm_scrobbles s
+    JOIN lastfm_tracks t ON t.id = s.track_id
+    JOIN lastfm_artists a ON a.id = t.artist_id
+    WHERE t.is_filtered = 0 AND a.is_filtered = 0
+  ),
+  unique_tracks = (
+    SELECT COUNT(DISTINCT s.track_id)
+    FROM lastfm_scrobbles s
+    JOIN lastfm_tracks t ON t.id = s.track_id
+    JOIN lastfm_artists a ON a.id = t.artist_id
+    WHERE t.is_filtered = 0 AND a.is_filtered = 0
+  ),
+  updated_at = datetime('now')
+WHERE user_id = 1;

--- a/src/routes/listening.test.ts
+++ b/src/routes/listening.test.ts
@@ -400,6 +400,90 @@ describe('listening routes', () => {
     });
   });
 
+  describe('GET /v1/listening/recent', () => {
+    let token: string;
+
+    beforeAll(async () => {
+      await setupTestDb();
+      token = await createTestApiKey({
+        name: 'recent-filtering',
+        scope: 'read',
+      });
+    });
+
+    beforeEach(async () => {
+      const db = drizzle(env.DB);
+      await db.delete(lastfmScrobbles);
+      await db.delete(lastfmTracks);
+      await db.delete(lastfmAlbums);
+      await db.delete(lastfmArtists);
+    });
+
+    it('requires the track, artist, and album to all be unfiltered', async () => {
+      const db = drizzle(env.DB);
+      const [musicArtist, filteredArtist, albumFilteredArtist] = await db
+        .insert(lastfmArtists)
+        .values([
+          { name: 'Music Artist', isFiltered: 0 },
+          { name: 'Filtered Author', isFiltered: 1 },
+          { name: 'Album Filter Artist', isFiltered: 0 },
+        ])
+        .returning();
+      const [musicAlbum, authorAlbum, filteredAlbum] = await db
+        .insert(lastfmAlbums)
+        .values([
+          { name: 'Music Album', artistId: musicArtist.id, isFiltered: 0 },
+          { name: 'Book', artistId: filteredArtist.id, isFiltered: 0 },
+          {
+            name: 'Filtered Album',
+            artistId: albumFilteredArtist.id,
+            isFiltered: 1,
+          },
+        ])
+        .returning();
+      const [musicTrack, authorTrack, albumTrack] = await db
+        .insert(lastfmTracks)
+        .values([
+          {
+            name: 'Song',
+            artistId: musicArtist.id,
+            albumId: musicAlbum.id,
+            isFiltered: 0,
+          },
+          {
+            name: 'Chapter',
+            artistId: filteredArtist.id,
+            albumId: authorAlbum.id,
+            isFiltered: 0,
+          },
+          {
+            name: 'Hidden Album Song',
+            artistId: albumFilteredArtist.id,
+            albumId: filteredAlbum.id,
+            isFiltered: 0,
+          },
+        ])
+        .returning();
+
+      await db.insert(lastfmScrobbles).values([
+        { trackId: musicTrack.id, scrobbledAt: '2026-08-08T20:00:00Z' },
+        { trackId: authorTrack.id, scrobbledAt: '2026-08-08T21:00:00Z' },
+        { trackId: albumTrack.id, scrobbledAt: '2026-08-08T22:00:00Z' },
+      ]);
+
+      const response = await SELF.fetch(
+        'http://localhost/v1/listening/recent?limit=10',
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      const body = (await response.json()) as {
+        data: Array<{ track: { name: string } }>;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body.data.map((item) => item.track.name)).toEqual(['Song']);
+    });
+  });
+
   describe('GET /v1/listening/recent/albums', () => {
     let token: string;
     let sequence = 0;

--- a/src/routes/listening.ts
+++ b/src/routes/listening.ts
@@ -9,6 +9,8 @@ import {
   like,
   asc,
   inArray,
+  isNull,
+  or,
   type SQL,
 } from 'drizzle-orm';
 import { createDb, type Database } from '../db/client.js';
@@ -1917,7 +1919,14 @@ listening.openapi(recentRoute, async (c) => {
     .innerJoin(lastfmTracks, eq(lastfmScrobbles.trackId, lastfmTracks.id))
     .innerJoin(lastfmArtists, eq(lastfmTracks.artistId, lastfmArtists.id))
     .leftJoin(lastfmAlbums, eq(lastfmTracks.albumId, lastfmAlbums.id))
-    .where(and(eq(lastfmTracks.isFiltered, 0), dateCondition))
+    .where(
+      and(
+        eq(lastfmTracks.isFiltered, 0),
+        eq(lastfmArtists.isFiltered, 0),
+        or(isNull(lastfmAlbums.id), eq(lastfmAlbums.isFiltered, 0)),
+        dateCondition
+      )
+    )
     .orderBy(desc(lastfmScrobbles.scrobbledAt))
     .limit(limit)
     .offset(offset);

--- a/src/services/lastfm/filters.test.ts
+++ b/src/services/lastfm/filters.test.ts
@@ -58,6 +58,11 @@ beforeAll(() => {
     { filterType: 'audiobook', pattern: '- Track \\d+', scope: 'track_regex' },
     { filterType: 'audiobook', pattern: '- \\d{2,3}$', scope: 'track_regex' },
     { filterType: 'audiobook', pattern: ' \\(\\d+\\)$', scope: 'track_regex' },
+    {
+      filterType: 'audiobook',
+      pattern: '- Section \\\\d+',
+      scope: 'track_regex',
+    },
   ]);
 });
 
@@ -140,6 +145,9 @@ describe('isAudiobook', () => {
     expect(
       isAudiobook({ artistName: 'Unknown', trackName: 'Something (12)' })
     ).toBe(true);
+    expect(
+      isAudiobook({ artistName: 'Unknown', trackName: 'Book - Section 12' })
+    ).toBe(true);
   });
 
   it('detects numbered audiobook chapters that repeat the album title', () => {
@@ -148,6 +156,14 @@ describe('isAudiobook', () => {
         artistName: 'Homer, Robert Fagles',
         albumName: 'The Odyssey',
         trackName: '006 - The Odyssey (Fagles translation)',
+      })
+    ).toBe(true);
+    expect(
+      isAudiobook({
+        artistName: 'Robert M. Pirsig',
+        albumName:
+          'Zen And The Art Of Motorcycle Maintenance: An Inquiry Into Values',
+        trackName: '(03 of 21) - Zen And The Art *',
       })
     ).toBe(true);
   });

--- a/src/services/lastfm/filters.ts
+++ b/src/services/lastfm/filters.ts
@@ -86,18 +86,31 @@ export function isHolidayMusic(item: FilterableItem): boolean {
 }
 
 export function hasNumberedAudiobookSignature(item: FilterableItem): boolean {
-  const albumLower = (item.albumName ?? '').toLowerCase();
-  const trackLower = (item.trackName ?? '').toLowerCase();
+  const albumName = item.albumName ?? '';
   const trackName = item.trackName ?? '';
 
-  // Audiobooks scrobbled by Plex commonly use a zero-padded file sequence
-  // followed by the book title (for example, "006 - The Odyssey ..."). The
-  // album-title check keeps this narrow enough to preserve legitimate numbered
-  // songs such as Bon Iver's "715 - CR∑∑KS".
+  // Prologue/Plex audiobook files commonly prefix the repeated book title
+  // with either a zero-padded sequence ("006 - The Odyssey ...") or a part
+  // counter ("(03 of 21) - Zen And The Art *"). Require title overlap after
+  // the counter so similarly numbered music files do not get excluded.
+  const match = trackName.match(
+    /^(?:\d{3}|\(\s*\d{1,3}\s+of\s+\d{1,3}\s*\))\s*-\s*(.+)$/i
+  );
+  if (!match) return false;
+
+  const normalizeTitle = (value: string): string =>
+    value
+      .toLowerCase()
+      .replace(/\*/g, '')
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
+      .trim();
+  const album = normalizeTitle(albumName);
+  const trackTitle = normalizeTitle(match[1]);
+
   return (
-    albumLower.length >= 5 &&
-    /^\d{3}\s+-\s+/.test(trackName) &&
-    trackLower.includes(albumLower)
+    album.length >= 5 &&
+    trackTitle.length >= 8 &&
+    (album.includes(trackTitle) || trackTitle.includes(album))
   );
 }
 
@@ -123,7 +136,11 @@ export function isAudiobook(item: FilterableItem): boolean {
     }
     if (rule.scope === 'track_regex') {
       try {
-        const regex = new RegExp(rule.pattern, 'i');
+        // SQLite string literals preserve backslashes. The original seed
+        // migration therefore stored regex escapes doubled ("\\\\d"), while
+        // rules created through the API contain a single slash. Accept both.
+        const pattern = rule.pattern.replace(/\\\\/g, '\\');
+        const regex = new RegExp(pattern, 'i');
         if (regex.test(trackName)) return true;
       } catch {
         // Invalid regex pattern, skip

--- a/src/services/lastfm/sync.test.ts
+++ b/src/services/lastfm/sync.test.ts
@@ -6,12 +6,15 @@ import {
   lastfmAlbums,
   lastfmTracks,
   lastfmScrobbles,
+  lastfmUserStats,
   lastfmYearlyStats,
 } from '../../db/schema/lastfm.js';
+import { syncRuns } from '../../db/schema/system.js';
 import { setupTestDb } from '../../test-helpers.js';
 import {
   syncRecentScrobbles,
   syncListening,
+  syncUserStats,
   syncYearlyStats,
   upsertAlbum,
   upsertArtist,
@@ -36,6 +39,8 @@ describe('syncRecentScrobbles audiobook filtering', () => {
 
   beforeEach(async () => {
     db = createDb(env.DB);
+    await db.delete(syncRuns);
+    await db.delete(lastfmUserStats);
     await db.delete(lastfmYearlyStats);
     await db.delete(lastfmScrobbles);
     await db.delete(lastfmTracks);
@@ -44,40 +49,151 @@ describe('syncRecentScrobbles audiobook filtering', () => {
     await loadFilters(db);
   });
 
-  it('cascades a numbered audiobook signature and omits it from feed/search candidates', async () => {
+  it('rejects Prologue audiobook history and advances the cursor past it', async () => {
+    const requestedFrom: Array<number | undefined> = [];
+    const client = {
+      getRecentTracks: async (params: { from?: number }) => {
+        requestedFrom.push(params.from);
+        return {
+          recenttracks: {
+            track: [
+              {
+                artist: { mbid: '', '#text': 'Robert M. Pirsig' },
+                name: '(03 of 21) - Zen And The Art *',
+                mbid: '',
+                album: {
+                  mbid: '',
+                  '#text':
+                    'Zen And The Art Of Motorcycle Maintenance: An Inquiry Into Values',
+                },
+                url: 'https://last.fm/test/zen',
+                date: { uts: '1786225450', '#text': '8 Aug 2026' },
+                image: [],
+              },
+            ],
+            '@attr': { totalPages: '1' },
+          },
+        };
+      },
+      getArtistTopTags: async () => {
+        throw new Error('Artist not found');
+      },
+    } as unknown as LastfmClient;
+
+    const first = await syncRecentScrobbles(db, client);
+    const second = await syncRecentScrobbles(db, client);
+
+    const artists = await db.select().from(lastfmArtists);
+    const albums = await db.select().from(lastfmAlbums);
+    const tracks = await db.select().from(lastfmTracks);
+    const scrobbles = await db.select().from(lastfmScrobbles);
+
+    expect(artists).toHaveLength(0);
+    expect(albums).toHaveLength(0);
+    expect(tracks).toHaveLength(0);
+    expect(scrobbles).toHaveLength(0);
+    expect(first.count).toBe(0);
+    expect(first.newArtists.size).toBe(0);
+    expect(first.newAlbums.size).toBe(0);
+    expect(second.count).toBe(0);
+    expect(requestedFrom).toEqual([undefined, 1786225451]);
+  });
+
+  it('keeps tag-detected audiobooks out of history', async () => {
     const client = {
       getRecentTracks: async () => ({
         recenttracks: {
           track: [
             {
-              artist: { mbid: '', '#text': 'Homer, Emily Wilson' },
-              name: '001 - The Iliad (Wilson translation)',
+              artist: { mbid: '', '#text': 'A New Author' },
+              name: 'Opening',
               mbid: '',
-              album: { mbid: '', '#text': 'The Iliad' },
-              url: 'https://last.fm/test/iliad',
-              date: { uts: '1785298519', '#text': '29 Jul 2026' },
+              album: { mbid: '', '#text': 'A New Book' },
+              url: 'https://last.fm/test/book',
+              date: { uts: '1786225450', '#text': '8 Aug 2026' },
               image: [],
             },
           ],
           '@attr': { totalPages: '1' },
         },
       }),
-      getArtistTopTags: async () => {
-        throw new Error('Artist not found');
-      },
+      getArtistTopTags: async () => ({
+        toptags: { tag: [{ name: 'Audiobook', count: 100 }] },
+      }),
     } as unknown as LastfmClient;
 
     const result = await syncRecentScrobbles(db, client);
-
     const [artist] = await db.select().from(lastfmArtists);
-    const [album] = await db.select().from(lastfmAlbums);
-    const [track] = await db.select().from(lastfmTracks);
+    const scrobbles = await db.select().from(lastfmScrobbles);
 
     expect(artist.isFiltered).toBe(1);
-    expect(album.isFiltered).toBe(1);
-    expect(track.isFiltered).toBe(1);
+    expect(scrobbles).toHaveLength(0);
+    expect(result.count).toBe(0);
     expect(result.newArtists.size).toBe(0);
     expect(result.newAlbums.size).toBe(0);
+  });
+
+  it('derives public totals from admitted history instead of Last.fm playcount', async () => {
+    const [musicArtist] = await db
+      .insert(lastfmArtists)
+      .values({ name: 'Music Artist', isFiltered: 0 })
+      .returning();
+    const [bookAuthor] = await db
+      .insert(lastfmArtists)
+      .values({ name: 'Book Author', isFiltered: 1 })
+      .returning();
+    const [musicAlbum] = await db
+      .insert(lastfmAlbums)
+      .values({
+        name: 'Music Album',
+        artistId: musicArtist.id,
+        isFiltered: 0,
+      })
+      .returning();
+    const [bookAlbum] = await db
+      .insert(lastfmAlbums)
+      .values({ name: 'Book', artistId: bookAuthor.id, isFiltered: 1 })
+      .returning();
+    const [musicTrack] = await db
+      .insert(lastfmTracks)
+      .values({
+        name: 'Song',
+        artistId: musicArtist.id,
+        albumId: musicAlbum.id,
+        isFiltered: 0,
+      })
+      .returning();
+    const [bookTrack] = await db
+      .insert(lastfmTracks)
+      .values({
+        name: 'Chapter',
+        artistId: bookAuthor.id,
+        albumId: bookAlbum.id,
+        isFiltered: 1,
+      })
+      .returning();
+
+    await db.insert(lastfmScrobbles).values([
+      { trackId: musicTrack.id, scrobbledAt: '2026-08-08T20:00:00Z' },
+      { trackId: bookTrack.id, scrobbledAt: '2026-08-08T21:00:00Z' },
+    ]);
+
+    const client = {
+      getUserInfo: async () => ({
+        user: {
+          playcount: '999999',
+          registered: { unixtime: '1704067200' },
+        },
+      }),
+    } as unknown as LastfmClient;
+
+    await syncUserStats(db, client);
+    const [stats] = await db.select().from(lastfmUserStats);
+
+    expect(stats.totalScrobbles).toBe(1);
+    expect(stats.uniqueArtists).toBe(1);
+    expect(stats.uniqueAlbums).toBe(1);
+    expect(stats.uniqueTracks).toBe(1);
   });
 });
 

--- a/src/services/lastfm/sync.ts
+++ b/src/services/lastfm/sync.ts
@@ -239,14 +239,49 @@ async function failSyncRun(
  * Get the timestamp of the most recent scrobble to use as the `from` parameter.
  */
 async function getLastScrobbleTimestamp(db: Database): Promise<number | null> {
+  const [latestRun] = await db
+    .select({ metadata: syncRuns.metadata })
+    .from(syncRuns)
+    .where(
+      and(
+        eq(syncRuns.domain, 'listening'),
+        eq(syncRuns.syncType, 'scrobbles'),
+        eq(syncRuns.status, 'completed')
+      )
+    )
+    .orderBy(desc(syncRuns.completedAt))
+    .limit(1);
+
+  let syncCursor: number | null = null;
+  if (latestRun?.metadata) {
+    try {
+      const parsed = JSON.parse(latestRun.metadata) as {
+        lastScrobbleTimestamp?: unknown;
+      };
+      if (
+        typeof parsed.lastScrobbleTimestamp === 'number' &&
+        Number.isFinite(parsed.lastScrobbleTimestamp)
+      ) {
+        syncCursor = parsed.lastScrobbleTimestamp;
+      }
+    } catch {
+      // Older sync metadata is best-effort; the stored history remains a
+      // safe fallback cursor.
+    }
+  }
+
   const [latest] = await db
     .select({ scrobbledAt: lastfmScrobbles.scrobbledAt })
     .from(lastfmScrobbles)
     .orderBy(desc(lastfmScrobbles.scrobbledAt))
     .limit(1);
 
-  if (!latest) return null;
-  return Math.floor(new Date(latest.scrobbledAt).getTime() / 1000);
+  const storedCursor = latest
+    ? Math.floor(new Date(latest.scrobbledAt).getTime() / 1000)
+    : null;
+  if (syncCursor === null) return storedCursor;
+  if (storedCursor === null) return syncCursor;
+  return Math.max(syncCursor, storedCursor);
 }
 
 /**
@@ -264,6 +299,7 @@ export async function syncRecentScrobbles(
 ): Promise<ScrobbleSyncResult> {
   const runId = await startSyncRun(db, 'scrobbles');
   let totalSynced = 0;
+  let totalFiltered = 0;
   const newArtists = new Map<string, string>();
   const newAlbums = new Map<
     string,
@@ -272,6 +308,7 @@ export async function syncRecentScrobbles(
 
   try {
     const lastTimestamp = await getLastScrobbleTimestamp(db);
+    let lastSeenTimestamp = lastTimestamp;
     // Add 1 second to avoid re-fetching the last scrobble
     const from = lastTimestamp ? lastTimestamp + 1 : undefined;
 
@@ -297,6 +334,16 @@ export async function syncRecentScrobbles(
         // Skip now-playing tracks (no timestamp)
         if (track.isNowPlaying || !track.scrobbledAt) continue;
 
+        const trackTimestamp = Math.floor(
+          new Date(track.scrobbledAt).getTime() / 1000
+        );
+        if (
+          Number.isFinite(trackTimestamp) &&
+          (lastSeenTimestamp === null || trackTimestamp > lastSeenTimestamp)
+        ) {
+          lastSeenTimestamp = trackTimestamp;
+        }
+
         const filterableTrack = {
           artistName: track.artistName,
           albumName: track.albumName,
@@ -305,6 +352,13 @@ export async function syncRecentScrobbles(
         const matchesAudiobookSignature =
           hasNumberedAudiobookSignature(filterableTrack);
         let filteredItem = isFiltered(filterableTrack);
+
+        // Reject known audiobook/holiday shapes at the admission boundary.
+        // They should never create listening entities or history rows.
+        if (filteredItem) {
+          totalFiltered++;
+          continue;
+        }
 
         const artist = await upsertArtist(
           db,
@@ -387,6 +441,14 @@ export async function syncRecentScrobbles(
           }
         }
 
+        // Tag-based and previously persisted artist filters are only known
+        // after the entity lookup. Keep the deny decision durable, but never
+        // write a listening-history row for the rejected item.
+        if (filteredItem) {
+          totalFiltered++;
+          continue;
+        }
+
         // Track new artists and albums for feed/search
         if (
           !filteredItem &&
@@ -432,12 +494,14 @@ export async function syncRecentScrobbles(
       page++;
     }
 
-    const lastTs = await getLastScrobbleTimestamp(db);
     await completeSyncRun(
       db,
       runId,
       totalSynced,
-      JSON.stringify({ lastScrobbleTimestamp: lastTs })
+      JSON.stringify({
+        lastScrobbleTimestamp: lastSeenTimestamp,
+        filtered: totalFiltered,
+      })
     );
 
     console.log(`[SYNC] Synced ${totalSynced} new scrobbles`);
@@ -848,21 +912,26 @@ export async function syncUserStats(
 
   try {
     const info = await client.getUserInfo();
-    const totalScrobbles = parseInt(info.user.playcount);
     const registeredDate = new Date(
       parseInt(info.user.registered.unixtime) * 1000
     ).toISOString();
 
-    // Count unique entities from local DB
-    const [artistCount] = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(lastfmArtists);
-    const [albumCount] = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(lastfmAlbums);
-    const [trackCount] = await db
-      .select({ count: sql<number>`count(*)` })
-      .from(lastfmTracks);
+    // Last.fm's account playcount includes scrobbles Rewind intentionally
+    // rejects (for example Prologue audiobooks). Derive every public count
+    // from admitted local history so excluded media never affects stats.
+    const [localStats] = await db
+      .select({
+        totalScrobbles: sql<number>`count(*)`,
+        uniqueArtists: sql<number>`count(distinct ${lastfmTracks.artistId})`,
+        uniqueAlbums: sql<number>`count(distinct ${lastfmTracks.albumId})`,
+        uniqueTracks: sql<number>`count(distinct ${lastfmScrobbles.trackId})`,
+      })
+      .from(lastfmScrobbles)
+      .innerJoin(lastfmTracks, eq(lastfmScrobbles.trackId, lastfmTracks.id))
+      .innerJoin(lastfmArtists, eq(lastfmTracks.artistId, lastfmArtists.id))
+      .where(
+        and(eq(lastfmTracks.isFiltered, 0), eq(lastfmArtists.isFiltered, 0))
+      );
 
     // Upsert stats (only one row per user)
     const [existing] = await db
@@ -872,10 +941,10 @@ export async function syncUserStats(
       .limit(1);
 
     const stats = {
-      totalScrobbles,
-      uniqueArtists: artistCount.count,
-      uniqueAlbums: albumCount.count,
-      uniqueTracks: trackCount.count,
+      totalScrobbles: localStats.totalScrobbles,
+      uniqueArtists: localStats.uniqueArtists,
+      uniqueAlbums: localStats.uniqueAlbums,
+      uniqueTracks: localStats.uniqueTracks,
       registeredDate,
       updatedAt: new Date().toISOString(),
     };
@@ -890,7 +959,9 @@ export async function syncUserStats(
     }
 
     await completeSyncRun(db, runId, 1);
-    console.log(`[SYNC] Updated user stats: ${totalScrobbles} total scrobbles`);
+    console.log(
+      `[SYNC] Updated user stats: ${localStats.totalScrobbles} total scrobbles`
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await failSyncRun(db, runId, message);
@@ -934,11 +1005,24 @@ export async function backfillScrobbles(
         const track = normalizeScrobble(rawTrack);
         if (track.isNowPlaying || !track.scrobbledAt) continue;
 
-        const { id: artistId } = await upsertArtist(
+        if (
+          isFiltered({
+            artistName: track.artistName,
+            albumName: track.albumName,
+            trackName: track.trackName,
+          })
+        ) {
+          continue;
+        }
+
+        const artist = await upsertArtist(
           db,
           track.artistName,
           track.artistMbid
         );
+        if (artist.isFiltered) continue;
+
+        const artistId = artist.id;
         const album = track.albumName
           ? await upsertAlbum(
               db,


### PR DESCRIPTION
## Summary
- recognize both existing zero-padded and Prologue/Plex `(N of M)` audiobook filename shapes
- reject filtered items before listening-history insertion and persist the sync high-water mark even when a batch is entirely rejected
- harden recent-listening and stats queries against filtered parent entities
- add an idempotent production cleanup for Robert M. Pirsig activity, search, images, top lists, and scrobbles

## Verification
- lint, Prettier, and TypeScript pass
- 1,046 tests pass
- Worker dry-run build passes
- migration replayed twice against a local D1 fixture; cleanup remained idempotent